### PR TITLE
Corrected minus sign in shift_t and added clause in isms.py

### DIFF
--- a/PSS_utils.py
+++ b/PSS_utils.py
@@ -10,7 +10,7 @@ import scipy as sp
 
 def shift_t(y, shift, dt=1):
     """Shift timeseries data in time.
-    Shift array, y, in time by amount, shift. For dt=1 units of samples 
+    Shift array, y, in time by amount, shift. For dt=1 units of samples
     (including fractional samples) are used. Otherwise, shift and dt are
     assumed to have the same physical units (i.e. seconds).
     Parameters
@@ -41,7 +41,7 @@ def shift_t(y, shift, dt=1):
     else:
         yfft = np.fft.rfft(y) # hermicity implicitely enforced by rfft
         fs = np.fft.rfftfreq(len(y), d=dt)
-        phase = -1j*2*np.pi*fs*shift
+        phase = 1j*2*np.pi*fs*shift
         yfft_sh = yfft * np.exp(phase)
         out = np.fft.irfft(yfft_sh)
     return out

--- a/ism.py
+++ b/ism.py
@@ -66,7 +66,10 @@ class ISM(object):
             self.K = 1.0/2.41e-4 #constant used to be more consistent with PSRCHIVE
             self.time_delays = -1e-3*self.K*self.DM*(np.power((self.freq_Array/1e3),-2)) #freq in MHz, delays in milliseconds
                 #Dispersion as compared to infinite frequency
-            self.time_delays = np.rint(self.time_delays//self.TimeBinSize) #Convert to number of bins
+            if self.MD.mode == 'explore':
+                self.time_delays = np.rint(self.time_delays//self.TimeBinSize) #Convert to number of bins
+            if self.MD.mode == 'simulate':
+                self.time_delays = (self.time_delays//self.TimeBinSize) #Convert to time in terms of bins
             self.widths = np.zeros(self.Nf)
             sub_band_width = self.bw/self.Nf
             for ii, freq in enumerate(self.freq_Array):


### PR DESCRIPTION
These commits correct the minus sign in the shift_t function and put an if clause in the `ism.py` `disperse()` method that chooses integer shifts for explore mode. We could give more options there if needed. 