### PR TITLE
fixes "sigS" the noise level

### DIFF
--- a/signal.py
+++ b/signal.py
@@ -62,6 +62,7 @@ class Signal(object):
             self.Npols = int(4)
             self.Nf = int(Nf)
             self.SignalDict['gauss_draw_max'] = np.iinfo(np.int8).max
+            self.SignalDict['data_type'] = np.int8
             # Set the correct standard deviation for the
             # pulse draws depending on data type.
 
@@ -71,6 +72,7 @@ class Signal(object):
             self.Npols = int(4)
             self.Nf = int(Nf)
             self.SignalDict['gauss_draw_max'] = np.iinfo(np.int16).max
+            self.SignalDict['data_type'] = np.int16
 
         elif SignalType == 'intensity' and data_type == 'int8':
             self.data_type = 'uint8'
@@ -78,6 +80,7 @@ class Signal(object):
             self.Npols = int(1)
             rows = self.Nf
             self.SignalDict['gamma_draw_max'] = np.iinfo(np.uint8).max
+            self.SignalDict['data_type'] = np.uint8
 
         elif SignalType == 'intensity' and data_type == 'int16':
             self.data_type = 'uint16'
@@ -85,6 +88,7 @@ class Signal(object):
             self.Npols = int(1)
             rows = self.Nf
             self.SignalDict['gamma_draw_max'] = np.iinfo(np.uint16).max
+            self.SignalDict['data_type'] = np.uint16
 
         else:
             raise ValueError('Signal Type: '+SignalType+' and data type: '+data_type+' not supported together.')

--- a/telescope.py
+++ b/telescope.py
@@ -144,6 +144,17 @@ class Telescope(object):
 
         if noise :
             out += self.radiometer_noise(signal, out.shape, dt_tel)
+        
+        if signal.SignalType == 'voltage':
+            clip = signal.MetaData.gauss_draw_max
+
+            out[out>clip] = clip
+            out[out<-clip] = -clip
+        else:
+            clip = signal.MetaData.gamma_draw_max
+            out[out>clip] = clip
+        
+        out = np.array(out, dtype=signal.MetaData.data_type)
 
         return out
 

--- a/telescope.py
+++ b/telescope.py
@@ -159,7 +159,13 @@ class Telescope(object):
         return out
 
     def radiometer_noise(self, signal, shape, dt):
-        # flux density fluctuations: sigS from Lorimer & Kramer eq 7.12
+        """compute radiometer white noise
+        signal -- signal object (needed for BW & Npol... should use telescope properties)
+        shape -- shape of output noise array (could probably be determined from telescope properties)
+        dt -- telescope sample rate in msec
+
+        flux density fluctuations: sigS from Lorimer & Kramer eq 7.12
+        """
         #TODO replace A with Aeff, depends on pointing for some telescopes
         #TODO Tsys -> Trec, compute Tsky, Tspill, Tatm from pointing
         dt *= 1.0e-3  # convert to sec

--- a/telescope.py
+++ b/telescope.py
@@ -143,21 +143,21 @@ class Telescope(object):
             raise ValueError("Signal Sampling Frequency Lower than Telescope Sampling Frequency")
 
         if noise :
-            out += self.radiometer_noise(signal, out.shape)
+            out += self.radiometer_noise(signal, out.shape, dt_tel)
 
         return out
 
-    def radiometer_noise(self, signal, shape):
+    def radiometer_noise(self, signal, shape, dt):
         # flux density fluctuations: sigS from Lorimer & Kramer eq 7.12
         #TODO replace A with Aeff, depends on pointing for some telescopes
         #TODO Tsys -> Trec, compute Tsky, Tspill, Tatm from pointing
-        Tobs = signal.TotTime * 1.0e-3  # convert to sec
+        dt *= 1.0e-3  # convert to sec
         BW = signal.bw  # MHz
         Np = signal.Npols
         G = self.area / (Np*_kB)  # K/Jy (gain)
         
         # noise variance
-        sigS = self.Tsys / G / np.sqrt(Np * Tobs * BW)  # mJy
+        sigS = self.Tsys / G / np.sqrt(Np * dt * BW)  # mJy
         
         if signal.SignalType == 'voltage':
             norm = np.sqrt(sigS) * signal.MetaData.gauss_draw_norm/signal.MetaData.Smax


### PR DESCRIPTION
Uses **dt** to compute the "noise variance per sample" from the radiometer equation rather than Tobs for the observation averaged variance.

This also converts `out` array to machine counts of the appropriate `data_type`