### PR TITLE
Added pip install command for PINT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,9 @@ python:
   - 2.7
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
-install: pip install -U tox-travis
+install:
+  - pip install -U tox-travis
+  - pip install git+https://github.com/nanograv/PINT.git@master
 
 # command to run tests, e.g. python setup.py test
 script: tox


### PR DESCRIPTION
I added in a pip install command for PINT. Just used the url for the PINT package since it is not in the PyPI .