### PR TITLE
Moved the PINT installation command

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps=flake8
 commands=flake8 psrsigsim
 
 [flake8]
-; E265 - block comment should start with '# ' 
+; E265 - block comment should start with '# '
 ; E225 - missing whitespace around operator
 ; default list: E121,E123,E126,E226,E24,E704,W503,W504
 ignore = E225, E265,
@@ -30,5 +30,5 @@ deps =
     -r{toxinidir}/requirements.txt
 commands =
     pip install -U pip
+    pip install git+https://github.com/nanograv/PINT.git@master
     py.test --basetemp={envtmpdir}
-


### PR DESCRIPTION
`PINT` is not acessible by Travis CI when installed in the `.yaml`, trying to put it in the tox file. 