### PR TITLE
correct links in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,15 +6,15 @@ PsrSigSim
 .. image:: https://img.shields.io/pypi/v/psrsigsim.svg
         :target: https://pypi.python.org/pypi/psrsigsim
 
-.. image:: https://img.shields.io/travis/PsrSigSim/VersionZeroPointZero.svg
-        :target: https://travis-ci.org/PsrSigSim/VersionZeroPointZero
+.. image:: https://img.shields.io/travis/PsrSigSim/PsrSigSim.svg
+        :target: https://travis-ci.org/PsrSigSim/PsrSigSim
 
 .. image:: https://readthedocs.org/projects/psrsigsim/badge/?version=latest
         :target: https://psrsigsim.readthedocs.io/en/latest/?badge=latest
         :alt: Documentation Status
 
-.. image:: https://pyup.io/repos/github/PsrSigSim/VersionZeroPointZero/shield.svg
-     :target: https://pyup.io/repos/github/PsrSigSim/VersionZeroPointZero
+.. image:: https://pyup.io/repos/github/PsrSigSim/PsrSigSim/shield.svg
+     :target: https://pyup.io/repos/github/PsrSigSim/PsrSigSim
      :alt: Updates
 
 

--- a/README.rst
+++ b/README.rst
@@ -12,10 +12,10 @@ PsrSigSim
 .. image:: https://readthedocs.org/projects/psrsigsim/badge/?version=latest
         :target: https://psrsigsim.readthedocs.io/en/latest/?badge=latest
         :alt: Documentation Status
-
-.. image:: https://pyup.io/repos/github/PsrSigSim/PsrSigSim/shield.svg
-     :target: https://pyup.io/repos/github/PsrSigSim/PsrSigSim
-     :alt: Updates
+..  THIS COMMENTS OUT THE pyup badge
+ .. image:: https://pyup.io/repos/github/PsrSigSim/PsrSigSim/shield.svg
+      :target: https://pyup.io/repos/github/PsrSigSim/PsrSigSim
+      :alt: Updates
 
 
 The NANOGrav pulsar signal simulator.


### PR DESCRIPTION
Fixes badge links in `README.rst`.  I don't think we can link to `readthedocs.org` until we take the repo public.

We have not linked the pyup bot to this repo.  I'm not sure we should.  I have commented out that badge for now.