### PR TITLE
Making Shift Signs Consistent

### DIFF
--- a/psrsigsim/PSS_utils.py
+++ b/psrsigsim/PSS_utils.py
@@ -7,14 +7,9 @@ import numpy as np
 import scipy as sp
 from astropy import units as u
 from pint import models
-#try:
-#    import pyfftw
-#    use_pyfftw = True
-#except:
-#    use_pyfftw = False
 
 
-def shift_t(y, shift, use_pyfftw=False, PE='FFTW_EXHAUSTIVE', dt=1):
+def shift_t(y, shift, dt=1):
     """Shift timeseries data in time.
     Shift array, y, in time by amount, shift. For dt=1 units of samples
     (including fractional samples) are used. Otherwise, shift and dt are
@@ -44,29 +39,14 @@ def shift_t(y, shift, use_pyfftw=False, PE='FFTW_EXHAUSTIVE', dt=1):
     """
     if isinstance(shift, int) and dt is 1:
         out = np.roll(y, shift)
+
     else:
-        if use_pyfftw:
-            pass
-            # #print('Starting rfft')
-            # #dummy_array = pyfftw.empty_aligned
-            # (self.Nt, dtype=self.MD.data_type)
-            # rfftw_Object = pyfftw.builders.rfft(y, planner_effort=PE)
-            # 'FFTW_EXHAUSTIVE'
-            # #print('Past rfft intialization')
-            # yfft = rfftw_Object(y) # hermicity implicitely enforced by rfft
-            # #print('Past rfft')
-            # fs = np.fft.rfftfreq(len(y), d=dt)
-            # phase = 1j*2*np.pi*fs*shift
-            # yfft_sh = yfft * np.exp(phase)
-            # irfftw_Object = pyfftw.builders.irfft(yfft_sh, planner_effort=PE)
-            #'FFTW_EXHAUSTIVE'
-            # out = irfftw_Object(yfft_sh)
-        else:
-            yfft = np.fft.rfft(y)  # hermicity implicitely enforced by rfft
-            fs = np.fft.rfftfreq(len(y), d=dt)
-            phase = 1j*2*np.pi*fs*shift
-            yfft_sh = yfft * np.exp(phase)
-            out = np.fft.irfft(yfft_sh)
+        yfft = np.fft.rfft(y)  # hermicity implicitely enforced by rfft
+        fs = np.fft.rfftfreq(len(y), d=dt)
+        phase = 1j*2*np.pi*fs*shift
+        yfft_sh = yfft * np.exp(phase)
+        out = np.fft.irfft(yfft_sh)
+
     return out
 
 
@@ -343,6 +323,6 @@ def get_pint_models(psr_name, psr_file_path):
         """Function that returns pint model given a specific pulsar"""
         # will need to add section for J1713 T2 file. gls is not file wanted for this specfic pulsar.
         model_name = "{0}{1}_NANOGrav_11yv1.gls.par".format(psr_file_path,psr_name)
-        par_model = models.get_model(model_name) 
+        par_model = models.get_model(model_name)
 
         return par_model

--- a/psrsigsim/PSS_utils.py
+++ b/psrsigsim/PSS_utils.py
@@ -43,7 +43,7 @@ def shift_t(y, shift, dt=1):
     else:
         yfft = np.fft.rfft(y)  # hermicity implicitely enforced by rfft
         fs = np.fft.rfftfreq(len(y), d=dt)
-        phase = 1j*2*np.pi*fs*shift
+        phase = -1j*2*np.pi*fs*shift
         yfft_sh = yfft * np.exp(phase)
         out = np.fft.irfft(yfft_sh)
 

--- a/psrsigsim/ism.py
+++ b/psrsigsim/ism.py
@@ -8,13 +8,12 @@ import sys, os, time
 import scipy.signal as spsig
 from . import PSS_utils as utils
 from . import scintillation as scint
-#try:
-#    import pyfftw
-#    use_pyfftw = True
-#except:
-use_pyfftw = False
 
-__all__ = ['ISM','scintillate','convolve_with_profile','make_dm_broaden_tophat','make_scatter_broaden_exp']
+
+__all__ = ['ISM','scintillate',
+           'convolve_with_profile',
+           'make_dm_broaden_tophat',
+           'make_scatter_broaden_exp']
 
 class ISM(object):
     def __init__(self, Signal_in, DM = 30):
@@ -39,7 +38,11 @@ class ISM(object):
         self.time_dependent_scatter = False
         self.time_dependent_DM = False
         if self.MD.mode == 'explore':
-            self.ISM_Dict = dict(tau_scatter = self.tau_scatter, DM = self.DM, dispersion=False, scattering=False, scintillation=False)
+            self.ISM_Dict = dict(tau_scatter = self.tau_scatter,
+                                 DM = self.DM,
+                                 dispersion=False,
+                                 scattering=False,
+                                 scintillation=False)
             self.ISM_Dict['dispersed'] = False
             self.ISM_Dict['to_DM_Broaden'] = self.to_DM_Broaden
             self.Signal_in.MetaData.AddInfo(self.ISM_Dict)
@@ -49,8 +52,13 @@ class ISM(object):
 
     def finalize_ism(self):
         if self.MD.mode=='explore':
-            raise ValueError('No Need to run finalize_ism() if simulator is in explore mode.')
-        self.ISM_Dict = dict(tau_scatter = self.tau_scatter, DM = self.DM, dispersion=False, scattering=False, scintillation=False)
+            raise ValueError('No Need to run finalize_ism()'
+                             'if simulator is in explore mode.')
+        self.ISM_Dict = dict(tau_scatter = self.tau_scatter,
+                             DM = self.DM,
+                             dispersion=False,
+                             scattering=False,
+                             scintillation=False)
         self.ISM_Dict['to_DM_Broaden'] = self.to_DM_Broaden
         self.ISM_Dict['to_Scatter_Broaden_exp'] = self.to_Scatter_Broaden_exp
         self.ISM_Dict['to_Scatter_Broaden_stoch'] = self.to_Scatter_Broaden_stoch
@@ -79,7 +87,7 @@ class ISM(object):
     def _disperse_filterbank(self):
         self.K = 1.0/2.41e-4 #constant used to be more consistent with PSRCHIVE
         #freq in MHz, delays in milliseconds
-        self.time_delays = -1e-3*self.K*self.DM \
+        self.time_delays = 1e-3*self.K*self.DM \
                            *(np.power((self.freq_Array/1e3),-2))
         #Dispersion as compared to infinite frequency
         if self.MD.mode == 'explore':

--- a/psrsigsim/ism.py
+++ b/psrsigsim/ism.py
@@ -61,7 +61,8 @@ class ISM(object):
                              scintillation=False)
         self.ISM_Dict['to_DM_Broaden'] = self.to_DM_Broaden
         self.ISM_Dict['to_Scatter_Broaden_exp'] = self.to_Scatter_Broaden_exp
-        self.ISM_Dict['to_Scatter_Broaden_stoch'] = self.to_Scatter_Broaden_stoch
+        self.ISM_Dict.update({'to_Scatter_Broaden_stoch':
+                             self.to_Scatter_Broaden_stoch})
         self.ISM_Dict['time_dependent_scatter'] = self.time_dependent_scatter
         self.ISM_Dict['time_dependent_DM'] = self.time_dependent_DM
         self.ISM_Dict['dispersed'] = False
@@ -126,7 +127,8 @@ class ISM(object):
         Broadens & delays baseband signal w transfer function defined in PSR
         Handbook, D. Lorimer and M. Kramer, 2006
         Returns a baseband signal dispersed by the ISM.
-        Use plot_dispersed() in PSS_plot.py to see the dispersed and undispersed signal.
+        Use plot_dispersed() in PSS_plot.py to see the
+        dispersed and undispersed signal.
         """
         #if self.ISM_Dict['dispersion'] == True:
         #    raise ValueError('Signal has already been dispersed!')
@@ -144,7 +146,8 @@ class ISM(object):
             u = np.fft.rfftfreq(2*len(fourier)-1,d=dt/1e3)*1e-6
             f = u-self.bw/2. # u in [0,bw], f in [-bw/2, bw/2]
 
-            H = np.exp(1j*2*np.pi*4.148808e9/((f+f0)*f0**2)*DM*f**2) # Lorimer & Kramer 2006, eqn. 5.21
+            # Lorimer & Kramer 2006, eqn. 5.21
+            H = np.exp(1j*2*np.pi*4.148808e9/((f+f0)*f0**2)*DM*f**2)
 
             product = fourier*H
             Dispersed = np.fft.irfft(product)
@@ -155,30 +158,39 @@ class ISM(object):
 
 
 class scintillate():
-    def __init__(self, Signal_in, V_ISS = None,scint_bw = None, scint_timescale = None, pulsar= None, to_use_NG_pulsar=False, telescope=None, freq_band=None):
+    def __init__(self, Signal_in, V_ISS = None,scint_bw = None,
+                 scint_timescale = None, pulsar= None, to_use_NG_pulsar=False,
+                 telescope=None, freq_band=None):
         """
-        Uses a phase screen with the given power spectrum to scintillate a pulsar signal
-        across an observation band. The class uses the parameters given to calculate
-        thin phase screens and gain image using Fresnel propagation.
+        Uses a phase screen with the given power spectrum to scintillate a
+        pulsar signal across an observation band. The class uses the parameters
+        given to calculate thin phase screens and gain image using Fresnel
+        propagation.
 
-        The screens are calculated for the size appropriate to the given parameters
-        and observation length.
+        The screens are calculated for the size appropriate to the given
+        parameters and observation length.
         """
 
         if pulsar == None and V_ISS==None and scint_timescale==None:
-            raise ValueError('Need to set a variable that sets the scintillation timescale.')
+            raise ValueError('Need to set a variable that'
+                             ' sets the scintillation timescale.')
 
         if pulsar != None and to_use_NG_pulsar:
             if telescope==None or freq_band==None:
-                raise ValueError('Must set both the telescope and bandwidth for {0}.'.format(pulsar))
+                raise ValueError('Must set both the telescope and'
+                                 ' bandwidth for {0}.'.format(pulsar))
 
-            self.scint_bw, self.scint_time = NG_scint_param(pulsar, telescope, freq_band)
+            self.scint_bw, self.scint_time = NG_scint_param(pulsar, telescope,
+                                                            freq_band)
 
             if scint_timescale != None:
-                print('Overiding scint_timescale value. Scintillation timescale set to {0} using Lam, et al. 2015.'.format(self.scint_time))
+                print('Overiding scint_timescale value.'
+                      ' Scintillation timescale set to '
+                      '{0} using Lam, et al. 2015.'.format(self.scint_time))
                 print('Change to_use_NG_pulsar flag to use entered value.')
             if V_ISS != None :
-                print('Overiding V_ISS value. Scintillation timescale set to {0} using Lam, et al. 2015.'.format(self.scint_time))
+                print('Overiding V_ISS value. Scintillation timescale set to '
+                      '{0} using Lam, et al. 2015.'.format(self.scint_time))
                 print('Change to_use_NG_pulsar flag to use entered value.')
 
         if pulsar == None and V_ISS==None and scint_timescale!=None:
@@ -189,14 +201,16 @@ class scintillate():
 
         #Should calculate Number_r_F for the particular scint_time.
 
-        diff_phase_screen = scint.phase_screen(Signal_in, Nx=400, Ny=150,Freq_DISS=self.scint_bw, Number_r_F=1/128.)
+        diff_phase_screen = scint.phase_screen(Signal_in, Nx=400, Ny=150,
+                                               Freq_DISS=self.scint_bw,
+                                               Number_r_F=1/128.)
 
         L = np.rint(diff_phase_screen.xmax//diff_phase_screen.r_Fresnel)
 
-        #refrac_phase_screen = scint.phase_screen(self.Signal_in, DM, Number_r_F=5)
         #Calculate a refraction screen to give a correction.
 
-        self.gain = scint.images(diff_phase_screen, Signal_in, mode='simulation').gain
+        self.gain = scint.images(diff_phase_screen,
+                                 Signal_in, mode='simulation').gain
         self.scint_time_sample_rate = 10 #Samples per scintillation time
         self.to_Scintillate = True
         self.Scint_Dict= {}
@@ -207,8 +221,8 @@ class scintillate():
         Signal_in.MetaData.AddInfo(self.Scint_Dict)
 
 def NG_scint_param(pulsar, telescope, freq_band, file_path=None):
-    """ Method for pulling scintillation bandwidth (MHz) and scintillation timescale (sec)
-    from a txt file.
+    """ Method for pulling scintillation bandwidth (MHz) and scintillation
+    timescale (sec) from a txt file.
     pulsar = Any of the NANOGrav pulsars from 9yr Data release in file.
                 See 'PTA_pulsar_nb_data.txt' for details.
     telescope  = 'AO' (Arecibo Obs) or 'GBT' (Greenbank Telescope)
@@ -218,8 +232,10 @@ def NG_scint_param(pulsar, telescope, freq_band, file_path=None):
         telescope = 'AO'
     if telescope == 'Greenbank':
         telescope = 'GBT'
-    freq_bands_txt = np.array(['0.327','0.430','0.820','1.400','2.300'], dtype=str)
-    freq_band = np.extract(freq_band==freq_bands_txt.astype(float)*1e3,freq_bands_txt)[0]
+    freq_bands_txt = np.array(['0.327','0.430','0.820','1.400','2.300'],
+                              dtype=str)
+    freq_band = np.extract(freq_band==freq_bands_txt.astype(float)*1e3,
+                           freq_bands_txt)[0]
 
     search_list = (pulsar, telescope, freq_band)
     columns = (10,11)
@@ -229,9 +245,14 @@ def NG_scint_param(pulsar, telescope, freq_band, file_path=None):
         file_path = path + '/PTA_pulsar_nb_data.txt'
 
     try:
-        scint_bw, scint_timescale = utils.text_search(search_list, columns, file_path)
+        scint_bw, scint_timescale = utils.text_search(search_list, columns,
+                                                      file_path)
     except:
-        raise ValueError('Combination of pulsar {0}, telescope {1} and bandwidth {2} MHz'.format(pulsar, telescope, freq_band)+' not found in txt file.')
+        err_msg =  'Combination of pulsar {0}, telescope {1}'.format(pulsar,
+                                                                     telescope)
+        err_msg += ' and bandwidth {0} MHz'.format(freq_band)
+        err_msg += ' not found in txt file.'
+        raise ValueError(err_msg)
 
     return scint_bw, scint_timescale
 
@@ -260,10 +281,11 @@ def convolve_with_profile(pulsar_object,input_array):
         input_array_norm = input_array[ii,:] / input_array_sum
 
         #Convolving the input array with the pulse profile
-        convolved_prof = spsig.convolve(pulsar_prof_norm, input_array_norm, mode='full',method='fft')
+        convolved_prof = spsig.convolve(pulsar_prof_norm, input_array_norm,
+                                        mode='full',method='fft')
 
         #Renormalizing the convolved pulse profile
-        pulsar_object.profile[ii,:] = (pulsar_prof_sum)*(convolved_prof[:width])
+        pulsar_object.profile[ii,:] = pulsar_prof_sum * convolved_prof[:width]
 
 def make_dm_broaden_tophat(pulsar_object,signal_object):
     """
@@ -287,20 +309,28 @@ def make_dm_broaden_tophat(pulsar_object,signal_object):
     """
 
     dm_widths = np.zeros(pulsar_object.Nf)
-    lowest_freq_top_hat_width = int(utils.top_hat_width(pulsar_object.bw / pulsar_object.Nf, pulsar_object.Signal_in.freq_Array[0], 100) // pulsar_object.TimeBinSize)
+    lowest_freq = pulsar_object.Signal_in.freq_Array[0]
+    lowest_freq_top_hat = utils.top_hat_width(freqBinSize,lowest_freq, 100)
+    lowest_freq_top_hat_width = np.ceil(lowest_freq_top_hat
+                                        /pulsar_object.TimeBinSize)
+
     tophat_array = np.zeros((pulsar_object.Nf,lowest_freq_top_hat_width))
 
     for ii, freq in enumerate(pulsar_object.Signal_in.freq_Array):
         #Creating the top hat array
 
         sub_band_width = pulsar_object.bw / pulsar_object.Nf
-        tophat_width = int(utils.top_hat_width(sub_band_width, freq, signal_object.MetaData.DM) // pulsar_object.TimeBinSize)
+        tophat_width = int(utils.top_hat_width(sub_band_width, freq,
+                                               signal_object.MetaData.DM)
+                                               // pulsar_object.TimeBinSize)
         if tophat_width > pulsar_object.Nt:
-            raise ValueError('Too Much DM! Dispersion broadening top hat wider than data array!')
+            raise ValueError('Too Much DM! Dispersion broadening '
+                             'top hat wider than data array!')
         dm_widths[ii] = tophat_width
         tophat = spsig.boxcar(tophat_width)
         tophat_len=len(tophat)
-        tophat = np.append(tophat,np.zeros(lowest_freq_top_hat_width-tophat_len))
+        tophat = np.append(tophat,
+                           np.zeros(lowest_freq_top_hat_width-tophat_len))
         tophat_array[ii,:] = tophat
 
     Dict = {'dm_widths':dm_widths}
@@ -330,7 +360,9 @@ def make_scatter_broaden_exp(pulsar_object, signal_object, tau_d_in=1):
     """
 
     width = pulsar_object.nBinsPeriod
-    tau_scatter_time = scint.scale_tau_d(tau_d = tau_d_in,nu_i = signal_object.f0,nu_f = signal_object.freq_Array)
+    tau_scatter_time = scint.scale_tau_d(tau_d = tau_d_in,
+                                         nu_i = signal_object.f0,
+                                         nu_f = signal_object.freq_Array)
     tau_scatter_bins = tau_scatter_time / signal_object.TimeBinSize
     t = np.linspace(0,pulsar_object.T,width)
     EXP_array = np.zeros((pulsar_object.Nf,width))


### PR DESCRIPTION
This pull request is opened to fix some issues with the `PSS_utils.shift_t()` method. The most important fix already made is to make the signs of the time shift consistent for the sub-methods within `shift_t()`. The changes fix problems accounted in  #52.  

I separated out a method from the `disperse()` method in order to make the code consistent between the filterbank (intensity) and baseband (voltage) signal types. 

I have also gone through and made a number of edits to avoid `lint` errors.