### PR TITLE
Fixed subint signal bug and sped up and added new telescope module tests

### DIFF
--- a/psrsigsim/pulsar/pulsar.py
+++ b/psrsigsim/pulsar/pulsar.py
@@ -119,12 +119,12 @@ class Pulsar(object):
         """
         if signal.subint:
             # Determine how many subints to make
-            if signal.sublen != None:
+            if signal.sublen is None:
+                signal._sublen = signal.tobs
+                signal._nsub = 1
+            else:
                 # This should be an integer, if not, will round
                 signal._nsub = int(np.round(signal.tobs / signal.sublen))
-            else:
-                signal.sublen = signal.tobs
-                signal._nsub = 1
             
             # determine the number of data samples necessary
             signal._nsamp = int((signal.nsub*(self.period*signal.samprate)).decompose())

--- a/psrsigsim/signal/fb_signal.py
+++ b/psrsigsim/signal/fb_signal.py
@@ -64,7 +64,7 @@ class FilterBankSignal(BaseSignal):
         self._bw = make_quant(bandwidth, 'MHz')
 
         self._subint = subint
-        if self.subint:
+        if self.subint and sublen != None:
             self._sublen = make_quant(sublen, 's')
         else:
             self._sublen = sublen

--- a/tests/test_telescope.py
+++ b/tests/test_telescope.py
@@ -69,18 +69,37 @@ def backend():
     
 def test_obs(tscope, receiver, backend, signal, pulsar):
     """
-    Test adding a system to the telescope
+    Test adding a system to the telescope and observing
     """
     tscope.add_system(name="Twnty_M", receiver=receiver, backend=backend)
-    tobs = make_quant(1,'s')
+    tobs = make_quant(0.02,'s')
     pulsar.make_pulses(signal,tobs)
     tscope.observe(signal, system="Twnty_M", noise=False)
 
 def test_noise(tscope, receiver, backend, signal, pulsar):
     """
-    Test adding a system to the telescope
+    Test adding a system to the telescope and observing with noise
     """
     tscope.add_system(name="Twnty_M", receiver=receiver, backend=backend)
-    tobs = make_quant(1,'s')
+    tobs = make_quant(0.02,'s')
     pulsar.make_pulses(signal,tobs)
     tscope.observe(signal, system="Twnty_M", noise=True)
+    
+def test_subint_obs(tscope, receiver, backend, subint_signal, pulsar):
+    """
+    Test adding a system to the telescope and observing with subint signal
+    """
+    tscope.add_system(name="Twnty_M", receiver=receiver, backend=backend)
+    tobs = make_quant(0.02,'s')
+    pulsar.make_pulses(subint_signal,tobs)
+    tscope.observe(subint_signal, system="Twnty_M", noise=False)
+
+def test_subint_noise(tscope, receiver, backend, subint_signal, pulsar):
+    """
+    Test adding a system to the telescope and observing with noise and subint
+    signal
+    """
+    tscope.add_system(name="Twnty_M", receiver=receiver, backend=backend)
+    tobs = make_quant(0.02,'s')
+    pulsar.make_pulses(subint_signal,tobs)
+    tscope.observe(subint_signal, system="Twnty_M", noise=True)


### PR DESCRIPTION
Fixed a bug in fb_signal where if the `sublen` value was not provided with `subint=True` the script would crash. Additionally fixed the automatic `sublen` setting in `make_pulses' and added and sped up `telescope` module unit tests.