### PR TITLE
Added `save` function, fixed S/N issue, other fixes

### DIFF
--- a/psrsigsim/io/psrfits.py
+++ b/psrsigsim/io/psrfits.py
@@ -106,11 +106,45 @@ class PSRFITS(BaseFile):
         elif self._fits_mode == 'auto':
             pass
         """
-        # We can only save single polarization
-        self.file.set_draft_header('SUBINT',{'POL_TYPE':'AA+BB'})
+        # We need to appropriatly shape the signal for the fits file
+        stop = self.nbin*self.nsubint
+        sim_sig = signal.data[:,:stop].astype('>i2')
+        # out arrays
+        Out = np.zeros((self.nsubint, self.npol, self.nchan, self.nbin))
+        print(np.shape(Out))
+        # We assign the data in the appropriate shape
+        for ii in range(self.nsubint):
+            idx0 = 0 + ii*2048
+            idxF = idx0 + 2048
+            Out[ii,0,:,:] = sim_sig[:,idx0:idxF]
         
-
-        raise NotImplementedError()
+        self.copy_psrfit_BinTables()
+        # We can currently only make total intensity data
+        self.file.set_draft_header('SUBINT',{'POL_TYPE':'AA+BB'})
+        """IMPORTANT NOTE: Currently phase connection is not implimented here! Still need to do this."""
+        for ii in range(self.nsubint):
+            self.file.HDU_drafts['SUBINT'][ii]['DATA'] = Out[ii,0,:,:]
+            self.file.HDU_drafts['SUBINT'][ii]['DAT_FREQ'] = signal.dat_freq.value
+            # Get the shapes of the wieghts, scales, and offs arrays, assumes we want to reset these to all be equal
+            if len(np.shape(self.file.fits_template[4][0]['DAT_SCL'])) != 1:
+                scale_shape = np.shape(self.file.fits_template[4][ii]['DAT_SCL'][:,:self.nchan*self.npol])
+                offs_shape = np.shape(self.file.fits_template[4][ii]['DAT_OFFS'][:,:self.nchan*self.npol])
+                weight_shape = np.shape(self.file.fits_template[4][ii]['DAT_WTS'])
+            else:
+                scale_shape = np.shape(self.file.fits_template[4][ii]['DAT_SCL'][:])
+                offs_shape = np.shape(self.file.fits_template[4][ii]['DAT_OFFS'][:])
+                weight_shape = np.shape(self.file.fits_template[4][ii]['DAT_WTS'])
+            # Now assign the values
+            #print(scale_shape, offs_shape, weight_shape)
+            self.file.HDU_drafts['SUBINT'][ii]['DAT_SCL'] = np.ones(scale_shape)
+            self.file.HDU_drafts['SUBINT'][ii]['DAT_OFFS'] = np.zeros(offs_shape)
+            self.file.HDU_drafts['SUBINT'][ii]['DAT_WTS'] = np.ones(weight_shape)
+        # Now we actually write out the files
+        self.file.write_psrfits(hdr_from_draft=True)
+        # Close the file so it doesn't take up memory or get confused with another file. 
+        self.file.close()
+        print("Finished writing and saving the file")
+        
 
     def append(self, signal):
         """Method for appending data to an already existing PSS signal file.
@@ -176,8 +210,8 @@ class PSRFITS(BaseFile):
                    subint=True,
                    sublen=self.tsubint)
 
-        S.freq_Array = self._get_pfit_bin_table_entry('SUBINT', 'DAT_FREQ')
-
+        S._dat_freq = make_quant(self._get_pfit_bin_table_entry('SUBINT', 'DAT_FREQ'), 'MHz')
+        
         return S
 
     def copy_psrfit_BinTables(self, ext_names='all', copy_SUBINT_nonDATA=True):
@@ -240,33 +274,55 @@ class PSRFITS(BaseFile):
         self.nchan = signal.Nf
         Nt = signal.Nt
 
-    def _get_signal_params(self):
+    def _get_signal_params(self, signal = None):
         """
         Calculate/retrieve the various parameters to make a PSS signal object
         from a given PSRFITS file.
-
-        Returns
-        -------
-        NChan, Nt
-        """
-        self._make_psrfits_pars_dict()
-        self.nchan = self.pfit_dict['NCHAN']
-        self.tbin = self.pfit_dict['TBIN']
-        self.nbin = self.pfit_dict['NBIN']
-        self.npol = self.pfit_dict['NPOL']
-        self.nrows = self.pfit_dict['NAXIS2']
-        self.nsblk = self.pfit_dict['NSBLK']
-        self.obsfreq = self.pfit_dict['OBSFREQ']
-        self.obsbw = self.pfit_dict['OBSBW']
-        self.chan_bw = self.pfit_dict['CHAN_BW']
-        self.stt_imjd = self.pfit_dict['STT_IMJD'] # start MJD of obs
-        self.stt_smjd = self.pfit_dict['STT_SMJD'] # start second of obs
-        self.tsubint = self.pfit_dict['TSUBINT'] # length of subint in seconds
         
-        if self.obs_mode=='PSR':
-            self.nsubint = self.nrows
+        if signal is given as a Signal() class object, then the values
+        will be taken from the signal class instead of a given PSRFITS
+        file.
+        """
+        # get paramters from fits file
+        if signal == None:
+            self._make_psrfits_pars_dict()
+            self.nchan = self.pfit_dict['NCHAN']
+            self.tbin = self.pfit_dict['TBIN']
+            self.nbin = self.pfit_dict['NBIN']
+            self.npol = self.pfit_dict['NPOL']
+            self.nrows = self.pfit_dict['NAXIS2']
+            self.nsblk = self.pfit_dict['NSBLK']
+            self.obsfreq = self.pfit_dict['OBSFREQ']
+            self.obsbw = self.pfit_dict['OBSBW']
+            self.chan_bw = self.pfit_dict['CHAN_BW']
+            self.stt_imjd = self.pfit_dict['STT_IMJD'] # start MJD of obs
+            self.stt_smjd = self.pfit_dict['STT_SMJD'] # start second of obs
+            self.tsubint = self.pfit_dict['TSUBINT'] # length of subint in seconds
+            
+            if self.obs_mode=='PSR':
+                self.nsubint = self.nrows
+            else:
+                self.nsubint = None
+        # get parameters from signal class
         else:
-            self.nsubint = None
+            self._make_psrfits_pars_dict()
+            self.nchan = signal.Nchan
+            self.tbin = 1.0/signal.samprate
+            self.nbin = int(signal.nsamp/signal.nsub)
+            self.npol = self.pfit_dict['NPOL']#signal.Npols
+            self.nrows = signal.nsub
+            self.nsblk = self.pfit_dict['NSBLK']
+            self.obsfreq = signal.fcent
+            self.obsbw = signal.bw
+            self.chan_bw = signal.bw / signal.Nchan
+            #self.stt_imjd = self.pfit_dict['STT_IMJD'] # start MJD of obs
+            #self.stt_smjd = self.pfit_dict['STT_SMJD'] # start second of obs
+            self.tsubint = signal.sublen # length of subint in seconds
+            
+            if self.obs_mode=='PSR':
+                self.nsubint = self.nrows
+            else:
+                self.nsubint = None
 
 
     def _make_psrfits_pars_dict(self):

--- a/psrsigsim/io/psrfits.py
+++ b/psrsigsim/io/psrfits.py
@@ -4,6 +4,8 @@
 from __future__ import (absolute_import, division,
                         print_function, unicode_literals)
 import numpy as np
+from packaging import version
+import fitsio
 import pdat
 from .file import BaseFile
 from ..utils import make_quant
@@ -322,8 +324,13 @@ class PSRFITS(BaseFile):
         """
         idx = self.file.draft_hdr_keys.index(extname)
         for val in self.file.fits_template[idx][:]:
-            if param == val[0].split()[0]:
-                return np.float64(val[0].split()[1].replace("D","E"))
+            # Have correction based on version of fitsio being used
+            if version.parse(fitsio.__version__) >= version.parse('1.0.1'):
+                if param == val[0].split()[0]:
+                    return np.float64(val[0].split()[1].replace("D","E"))
+            else:
+                if param == val[0].split()[0].decode("utf-8"):
+                    return np.float64(val[0].split()[1].decode("utf-8").replace("D","E"))
 
     #### Define various PSRFITS parameters
     @property

--- a/psrsigsim/ism/__init__.py
+++ b/psrsigsim/ism/__init__.py
@@ -1,0 +1,5 @@
+
+from .ism import ISM
+
+__all__ = ["ISM",
+        ]

--- a/psrsigsim/pulsar/pulsar.py
+++ b/psrsigsim/pulsar/pulsar.py
@@ -11,20 +11,20 @@ from ..utils.utils import make_quant
 class Pulsar(object):
     """class for pulsars
 
-    The minimal data to instatiate a pulsar is the period, intensity, and
+    The minimal data to instatiate a pulsar is the period, Smean, and
     pulse profile. The Profile is supplied via a :class:`PulseProfile`-like
     object.
 
     Args:
         period (float): pulse period (sec)
-        intensity (float): mean pulse intensity (Jy)
+        Smean (float): mean pulse flux density (Jy)
         profile (:class:`PulseProfile`): pulse profile or 2-D pulse portrait
         name (string): name of pulsar
     """
     #TODO Other data could be supplied via a `.par` file.
-    def __init__(self, period, intensity, profile=None, name=None):
+    def __init__(self, period, Smean, profile=None, name=None):
         self._period = make_quant(period, 's')
-        self._intensity = make_quant(intensity, 'Jy')
+        self._Smean = make_quant(Smean, 'Jy')
 
         self._name = name
         
@@ -51,8 +51,8 @@ class Pulsar(object):
         return self._period
 
     @property
-    def intensity(self):
-        return self._intensity
+    def Smean(self):
+        return self._Smean
 
     def make_pulses(self, signal, tobs):
         """generate pulses from Profile, :class:`PulseProfile` object
@@ -78,9 +78,8 @@ class Pulsar(object):
 
         # compute Smax (needed for radiometer noise level)
         pr = self.Profile()
-        dph = 1 / len(self.Profile())
-        norm = 1 / signal.Nchan
-        signal._Smax = self.intensity / (np.sum(pr) * dph * norm)
+        nbins = len(self.Profile()) # Think this assumes a single profile for now...
+        signal._Smax = self.Smean * nbins / np.sum(pr)
 
     def _make_amp_pulses(self, signal):
         """generate amplitude pulses

--- a/psrsigsim/signal/fb_signal.py
+++ b/psrsigsim/signal/fb_signal.py
@@ -59,9 +59,16 @@ class FilterBankSignal(BaseSignal):
                  subint=False,
                  sublen=None,
                  dtype=np.float32):
+        
+        # Currently only simulate total intensity
+        self._Npols = 1
 
         self._fcent = make_quant(fcent, 'MHz')
-        self._bw = make_quant(bandwidth, 'MHz')
+        # Check if bandwidth is negative; only an issue when making signal from fitsfile
+        if bandwidth < 0:
+            self._bw = make_quant(np.abs(bandwidth), 'MHz')
+        else:
+            self._bw = make_quant(bandwidth, 'MHz')
 
         self._subint = subint
         if self.subint and sublen != None:

--- a/psrsigsim/signal/signal.py
+++ b/psrsigsim/signal/signal.py
@@ -44,7 +44,11 @@ class BaseSignal(object):
                  Npols=1):
 
         self._fcent = fcent
-        self._bw = bandwidth
+        # Check if bandwidth is negative; only an issue when making signal from fitsfile
+        if bandwidth < 0:
+            self._bw = np.abs(bandwidth)
+        else:
+            self._bw = bandwidth
         self._samprate = sample_rate
         if dtype is np.float32 or np.int8:
             self._dtype = dtype
@@ -129,6 +133,10 @@ class BaseSignal(object):
     @property
     def Npols(self):
         return self._Npols
+    
+    @property
+    def dat_freq(self):
+        return self._dat_freq
 
 
 def Signal():

--- a/psrsigsim/telescope/telescope.py
+++ b/psrsigsim/telescope/telescope.py
@@ -69,9 +69,10 @@ class Telescope(object):
         append new system to dict systems"""
         self._systems[name] = (receiver, backend)
 
-    def observe(self, signal, system=None, mode='search', noise=False):
+    def observe(self, signal, pulsar, system=None, mode='search', noise=False):
         """observe(signal, system=None, mode='search', noise=False)
         signal -- Signal() instance
+        pulsar -- Pulsar() object, necessary for radiometer noise scaling
         system -- dict key for system to use
         """
         msg = "sig samp freq = {0:.3f} kHz\ntel samp freq = {1:.3f} kHz"
@@ -127,7 +128,7 @@ class Telescope(object):
             # The noise is getting added to the data in the radiometer noise function; this function as no output
             # Need to look into this resampling as well
             #out += rcvr.radiometer_noise(signal, gain=1) 
-            rcvr.radiometer_noise(signal, gain=self.gain)
+            rcvr.radiometer_noise(signal, pulsar, gain=self.gain)
             
 
         if signal.sigtype == 'voltage':

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ matplotlib>=2.1.1
 h5py>=2.7.0
 astropy>=2.0
 pdat>=0.2
+fitsio==0.9.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ matplotlib>=2.1.1
 h5py>=2.7.0
 astropy>=2.0
 pdat>=0.2
-fitsio==0.9.11
+fitsio==0.9.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ h5py>=2.7.0
 astropy>=2.0
 pdat>=0.2
 fitsio==0.9.12
+packaging>=19.1

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -19,7 +19,8 @@ def pulsar():
     """
     Fixture pulsar class
     """
-    period = make_quant(5,'ms')
+    F0 = 186.49408124993144
+    period = make_quant(1.0/F0,'s')
     return Pulsar(period,10,name='J1746-0118')
 
 @pytest.fixture
@@ -31,11 +32,19 @@ def PSRfits():
     tempfits = "data/B1855+09.L-wide.PUPPI.11y.x.sum.sm"
     return PSRFITS(path=fitspath, template=tempfits, fits_mode='copy')
 
-def test_fitssig(PSRfits, pulsar):
+def test_fitssig(PSRfits):
     """
-    Test getting a signal from a fits file and making pulses with it.
+    Test getting a signal from a fits file.
+    """
+    S = PSRfits.make_signal_from_psrfits()
+    os.remove("data/test.fits")
+    
+def test_savesig(PSRfits, pulsar):
+    """
+    Test getting a signal from a fits file, making pulses with it, and save it.
     """
     S = PSRfits.make_signal_from_psrfits()
     obslen = PSRfits.tsubint.value*PSRfits.nsubint
-    pulsar.make_pulses(S, tobs = obslen )
+    pulsar.make_pulses(S, tobs = obslen)
+    PSRfits.save(S)
     os.remove("data/test.fits")

--- a/tests/test_telescope.py
+++ b/tests/test_telescope.py
@@ -74,7 +74,7 @@ def test_obs(tscope, receiver, backend, signal, pulsar):
     tscope.add_system(name="Twnty_M", receiver=receiver, backend=backend)
     tobs = make_quant(0.02,'s')
     pulsar.make_pulses(signal,tobs)
-    tscope.observe(signal, system="Twnty_M", noise=False)
+    tscope.observe(signal, pulsar, system="Twnty_M", noise=False)
 
 def test_noise(tscope, receiver, backend, signal, pulsar):
     """
@@ -83,7 +83,7 @@ def test_noise(tscope, receiver, backend, signal, pulsar):
     tscope.add_system(name="Twnty_M", receiver=receiver, backend=backend)
     tobs = make_quant(0.02,'s')
     pulsar.make_pulses(signal,tobs)
-    tscope.observe(signal, system="Twnty_M", noise=True)
+    tscope.observe(signal, pulsar, system="Twnty_M", noise=True)
     
 def test_subint_obs(tscope, receiver, backend, subint_signal, pulsar):
     """
@@ -92,7 +92,7 @@ def test_subint_obs(tscope, receiver, backend, subint_signal, pulsar):
     tscope.add_system(name="Twnty_M", receiver=receiver, backend=backend)
     tobs = make_quant(0.02,'s')
     pulsar.make_pulses(subint_signal,tobs)
-    tscope.observe(subint_signal, system="Twnty_M", noise=False)
+    tscope.observe(subint_signal, pulsar, system="Twnty_M", noise=False)
 
 def test_subint_noise(tscope, receiver, backend, subint_signal, pulsar):
     """
@@ -102,4 +102,4 @@ def test_subint_noise(tscope, receiver, backend, subint_signal, pulsar):
     tscope.add_system(name="Twnty_M", receiver=receiver, backend=backend)
     tobs = make_quant(0.02,'s')
     pulsar.make_pulses(subint_signal,tobs)
-    tscope.observe(subint_signal, system="Twnty_M", noise=True)
+    tscope.observe(subint_signal, pulsar, system="Twnty_M", noise=True)

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,8 @@ deps =
     -r{toxinidir}/requirements_dev.txt
     -r{toxinidir}/requirements.txt
 commands =
-    pip install -U pip
+    python -m pip install --upgrade pip
+    pip install --upgrade setuptools
     pip install jplephem
     pip install git+https://github.com/nanograv/PINT.git@master
     py.test --basetemp={envtmpdir}


### PR DESCRIPTION
I've added a `save` function to save the simulated data to a template PSRFITS file and written a test for it as in #70 . Also added functionality to the `get_signal_params` function to get the parameters from a `Signal` class object, not just a template PSRFITS file. 
Fixed the signal-to-noise ratio issue in the radiometer equation in the receiver class by adding the appropriate scaling factor due to profile normalization as in #69 . As a consequence of this, `pulsar` object is now required in radiometer noise equation, `test_telescope` has thus been updated as well. 
Changed `intensity` to `Smean` as initial `Pulsar` input and corrected `Smax` calculation accordingly.
Changed all references of `freq_Array` to `dat_freq` for consistency. 
Fixed `ism.__init__` so that `ism` class is callable from psrsigsim import.