### PR TITLE
Added default single pulse filterbank mode

### DIFF
--- a/psrsigsim/io/psrfits.py
+++ b/psrsigsim/io/psrfits.py
@@ -162,6 +162,9 @@ class PSRFITS(BaseFile):
         """Method to make a signal from the PSRFITS file given as the template.
         For subintegrated data will assume the initial period is the pulsar 
         period given in the PSRPARAM header.
+        
+        TODO: Currently does not support generating 'SEARCH' mode data from
+            a psrfits file
 
         Parameters
         ----------
@@ -195,7 +198,8 @@ class PSRFITS(BaseFile):
                    Nsubband=self.nchan,
                    sample_rate=s_rate,
                    dtype=np.float32,
-                   subint=True,
+                   #subint=True,
+                   fold = True,
                    sublen=self.tsubint)
 
         S._dat_freq = make_quant(self._get_pfit_bin_table_entry('SUBINT', 'DAT_FREQ'), 'MHz')

--- a/psrsigsim/io/psrfits.py
+++ b/psrsigsim/io/psrfits.py
@@ -190,18 +190,6 @@ class PSRFITS(BaseFile):
             ObsTime = self.tbin*self.nbin*self.nsblk*self.nrows
             s_rate = (1/self.tbin).to('MHz').value
 
-        #TODO Delete calls to .value when integrated with new API.
-        #TODO Change call to FilterBank for new API.
-        """S = Signal(f0=self.obsfreq.value,
-                   bw=self.obsbw.value,
-                   Nf=self.nchan,
-                   f_samp=(1/self.tbin).to('MHz').value,
-                   ObsTime=ObsTime.to('ms').value,
-                   data_type='float32',
-                   SignalType='intensity',
-                   mode='simulate',
-                   clean_mode=True)
-        """
         S = FilterBankSignal(fcent=self.obsfreq.value,
                    bandwidth=self.obsbw.value,
                    Nsubband=self.nchan,

--- a/psrsigsim/ism/ism.py
+++ b/psrsigsim/ism/ism.py
@@ -5,6 +5,7 @@ from scipy import stats
 import sys, time
 from ..utils.utils import make_quant, shift_t
 from ..utils.constants import DM_K
+from ..utils.constants import KOLMOGOROV_BETA
 
 class ISM(object):
     '''
@@ -106,8 +107,6 @@ class ISM(object):
             time_delays += np.double(-1.0*make_quant(FD_params[ii], 's').to('ms') * \
                     np.power(np.log(freq_array/ref_freq),ii+1)) # will be in seconds
         
-        # convert to ms
-        time_delays.to('ms')
         # get time shift based on the sample rate
         shift_dt = (1/signal._samprate).to('ms')
         shift_start = time.time()
@@ -133,4 +132,125 @@ class ISM(object):
         
         # May need to add tihs parameter to signal
         signal._FDshifted = True
-
+    
+    def scatter_broaden(self, signal, tau_d, ref_freq, beta = KOLMOGOROV_BETA, \
+                        convolve = False, pulsar = None):
+        """
+        Function to add scatter broadening delays to simulated data. We offer
+        two methods to do this, one where the delay is calcuated and the 
+        pulse signals is directly shifted by the calculated delay (as done
+        in the disperse function), or the scattering delay exponentials are 
+        directy convolved with the pulse profiles. If this option is chosen, 
+        the scatter broadening must be done BEFORE pulsar.make_pulses() is run.
+        
+        signal [object] : signal class object which has been previously defined
+        tau_d [float] : scattering delay [seconds]
+        ref_freq [float] : reference frequency [MHz] at which tau_d was measured
+        beta [float] : preferred scaling law for tau_d, default is for a 
+                       Kolmoogorov medium (11/3)
+        convolve [bool] : If False, signal will be directly shifted in time by
+                          scattering delay; if True, scattering delay tails
+                          will be directly convolved with the pulse profiles.
+        pulsar [object] : previously defined pulsar class object with profile
+                          already assigned
+        """
+        # First get and define values to use
+        freq_array = signal._dat_freq
+        ref_freq = make_quant(ref_freq, 'MHz')
+        tau_d = make_quant(tau_d, 's').to('ms') # need compatible units with dt
+        # Scale the scattering timescale with frequency
+        tau_d_scaled = self.scale_tau_d(tau_d, ref_freq , freq_array, beta=beta)
+        # First shift signal if convolve = False
+        if not convolve:
+            # define bin size to shift by
+            shift_dt = (1/signal._samprate).to('ms')
+            shift_start = time.time()
+            # now loop through and scale things appropriately
+            for ii, freq in enumerate(freq_array):
+                signal._data[ii,:] = shift_t(signal._data[ii,:],
+                                             tau_d_scaled[ii].value,
+                                             dt=shift_dt.value)
+                if (ii+1) % int(signal.Nchan//20) ==0:
+                    shift_check = time.time()
+                    percent = round((ii + 1)*100/signal.Nchan)
+                    elapsed = shift_check-shift_start
+                    chk_str = '\r{0:2.0f}% scatter shifted'.format(percent)
+                    chk_str += ' in {0:4.3f} seconds.'.format(elapsed)
+    
+                    try:
+                        print(chk_str , end='', flush=True)
+                    #This is the Python 2 version
+                    #__future__ does not have 'flush' kwarg.
+                    except:
+                        print(chk_str , end='')
+                    sys.stdout.flush()
+        else:
+            # Determine the exponential scattering tails
+            """
+            --> We need to figure out how the 2-D profiles will work and fit 
+                in with the current data structure, such as in make_pulses()
+                and init_data() because this convolution needs to happen
+                before make pulses I think?
+            """
+            raise NotImplementedError()
+        
+    
+    '''
+    Written by Michael Lam, 2017
+    Scale dnu_d and dt_d based on:
+    dnu_d propto nu^(22/5)
+    dt_d propto nu^(6/5) / transverse velocity
+    See Stinebring and Condon 1990 for scalings with beta (they call it alpha)
+    
+    TODO: Should units be assigned here, or earlier?
+    '''
+    
+    def scale_dnu_d(dnu_d,nu_i,nu_f,beta=KOLMOGOROV_BETA):
+        """
+        Scaling law for scintillation bandwidth as a function of frequency.
+        dnu_d [float] : scintillation bandwidth [MHz]
+        nu_i [float] : reference frequency at which du_d was measured [MHz]
+        nu_f [float] : frequency (or frequency array) to scale dnu_d to [MHz]
+        beta [float] : preferred scaling law for dnu_d, default is for a 
+                       Kolmoogorov medium (11/3)
+        """
+        #dnu_d = make_quant(dnu_d, 'MHz')
+        if beta < 4:
+            exp = 2.0*beta/(beta-2) #(22.0/5)
+        elif beta > 4:
+            exp = 8.0/(6-beta)
+        return dnu_d*(nu_f/nu_i)**exp
+    
+    def scale_dt_d(dt_d,nu_i,nu_f,beta=KOLMOGOROV_BETA):
+        """
+        Scaling law for scintillation timescale as a function of frequency.
+        dt_d [float] : scintillation timescale [seconds]
+        nu_i [float] : reference frequency at which du_d was measured [MHz]
+        nu_f [float] : frequency (or frequency array) to scale dnu_d to [MHz]
+        beta [float] : preferred scaling law for dt_d, default is for a 
+                       Kolmoogorov medium (11/3)
+        """
+       # dt_d = make_quant(dt_d, 's')
+        if beta < 4:
+            exp = 2.0/(beta-2) #(6.0/5)
+        elif beta > 4:
+            exp = float(beta-2)/(6-beta)
+        return dt_d*(nu_f/nu_i)**exp
+    
+    def scale_tau_d(tau_d,nu_i,nu_f,beta=KOLMOGOROV_BETA):
+        """
+        Scaling law for the scattering timescale as a function of frequency.
+        tau_d [float] : scattering timescale [seconds?]
+        nu_i [float] : reference frequency at which du_d was measured [MHz]
+        nu_f [float] : frequency (or frequency array) to scale dnu_d to [MHz]
+        beta [float] : preferred scaling law for tau_d, default is for a 
+                       Kolmoogorov medium (11/3)
+        """
+        #tau_d = make_quant(tau_d, 's')
+        if beta < 4:
+            exp = -2.0*beta/(beta-2) #(-22.0/5)
+        elif beta > 4:
+            exp = -8.0/(6-beta)
+        return tau_d*(nu_f/nu_i)**exp
+    
+    

--- a/psrsigsim/ism/ism.py
+++ b/psrsigsim/ism/ism.py
@@ -205,7 +205,7 @@ class ISM(object):
     TODO: Should units be assigned here, or earlier?
     '''
     
-    def scale_dnu_d(dnu_d,nu_i,nu_f,beta=KOLMOGOROV_BETA):
+    def scale_dnu_d(self,dnu_d,nu_i,nu_f,beta=KOLMOGOROV_BETA):
         """
         Scaling law for scintillation bandwidth as a function of frequency.
         dnu_d [float] : scintillation bandwidth [MHz]
@@ -221,7 +221,7 @@ class ISM(object):
             exp = 8.0/(6-beta)
         return dnu_d*(nu_f/nu_i)**exp
     
-    def scale_dt_d(dt_d,nu_i,nu_f,beta=KOLMOGOROV_BETA):
+    def scale_dt_d(self,dt_d,nu_i,nu_f,beta=KOLMOGOROV_BETA):
         """
         Scaling law for scintillation timescale as a function of frequency.
         dt_d [float] : scintillation timescale [seconds]
@@ -237,7 +237,7 @@ class ISM(object):
             exp = float(beta-2)/(6-beta)
         return dt_d*(nu_f/nu_i)**exp
     
-    def scale_tau_d(tau_d,nu_i,nu_f,beta=KOLMOGOROV_BETA):
+    def scale_tau_d(self,tau_d,nu_i,nu_f,beta=KOLMOGOROV_BETA):
         """
         Scaling law for the scattering timescale as a function of frequency.
         tau_d [float] : scattering timescale [seconds?]

--- a/psrsigsim/pulsar/pulsar.py
+++ b/psrsigsim/pulsar/pulsar.py
@@ -116,7 +116,7 @@ class Pulsar(object):
         Args:
             signal (:class:`Signal`-like): signal object to store pulses
         """
-        if signal.subint:
+        if signal.fold:
             # Determine how many subints to make
             if signal.sublen is None:
                 signal._sublen = signal.tobs
@@ -141,6 +141,11 @@ class Pulsar(object):
             signal._data = (sngl_prof * distr.rvs(size=signal.data.shape)
                             * signal._draw_norm)
         else:
+            # fold is false and will make single pulses
+            signal._sublen = self.period
+            # This should be an integer, if not, will round; may not be exact
+            signal._nsub = int(np.round((signal.tobs / signal.sublen).decompose()))
+            
             # generate several pulses in time
             distr = stats.chi2(df=1)
             signal._set_draw_norm(df=1)

--- a/psrsigsim/signal/fb_signal.py
+++ b/psrsigsim/signal/fb_signal.py
@@ -33,7 +33,8 @@ class FilterBankSignal(BaseSignal):
             the 20.48 us per sample (about 50 kHz).  This is the sample rate
             for coherently dedispersed filter banks using XUPPI backends.
 
-        subint [bool]: is this a folded subintegration, default ``False``
+        # subint is now depricated for 'FOLD'
+        #subint [bool]: is this a folded subintegration, default ``False``
         
         sublen [float]: desired length of data subintegration (sec) if subint
             is ``True``, default: ``tobs``. If left as none but subint is 
@@ -42,6 +43,12 @@ class FilterBankSignal(BaseSignal):
 
         dtype [type]: data type of array, default: ``np.float32``
             supported types are: ``np.float32`` and ``np.int8``
+        
+        fold [bool]: If `True`, the initialized signal will be folded to some
+            number of subintegrations based on sublen (else will just make
+            a single subintegration). If `False`, the data produced will be
+            single pulse filterbank data. Default is `True`.
+            NOTE - using `False` will generate a large amount of data.
     """
     #TODO: full stokes.  Currently this is just stokes-I
     #  add flag `fullstokes=False`
@@ -56,9 +63,10 @@ class FilterBankSignal(BaseSignal):
                  fcent, bandwidth,
                  Nsubband=512,
                  sample_rate=None,
-                 subint=False,
+                 #subint=False,
                  sublen=None,
-                 dtype=np.float32):
+                 dtype=np.float32,
+                 fold=True):
         
         # Currently only simulate total intensity
         self._Npols = 1
@@ -70,11 +78,12 @@ class FilterBankSignal(BaseSignal):
         else:
             self._bw = make_quant(bandwidth, 'MHz')
 
-        self._subint = subint
-        if self.subint and sublen != None:
+        self._fold = fold
+        if self.fold and sublen != None:
             self._sublen = make_quant(sublen, 's')
         else:
             self._sublen = sublen
+            
         
         f_Nyquist = 2 * self._bw # Not sure if we need this for subintegrated data
         if sample_rate is None:
@@ -106,9 +115,13 @@ class FilterBankSignal(BaseSignal):
             self._draw_max = np.iinfo(np.int8).max
             self._draw_norm = self._draw_max/limit
 
+    #@property
+    #def subint(self):
+    #    return self._subint
+    
     @property
-    def subint(self):
-        return self._subint
+    def fold(self):
+        return self._fold
     
     @property
     def sublen(self):

--- a/psrsigsim/telescope/telescope.py
+++ b/psrsigsim/telescope/telescope.py
@@ -69,11 +69,12 @@ class Telescope(object):
         append new system to dict systems"""
         self._systems[name] = (receiver, backend)
 
-    def observe(self, signal, pulsar, system=None, mode='search', noise=False):
+    def observe(self, signal, pulsar, system=None, noise=False):
         """observe(signal, system=None, mode='search', noise=False)
         signal -- Signal() instance
         pulsar -- Pulsar() object, necessary for radiometer noise scaling
         system -- dict key for system to use
+        #NOTE: 'mode' variable was removed as signal contains same information
         """
         msg = "sig samp freq = {0:.3f} kHz\ntel samp freq = {1:.3f} kHz"
         rcvr = self.systems[system][0]
@@ -118,11 +119,9 @@ class Telescope(object):
             # input signal has lower samp freq than telescope samp freq
             #raise ValueError("Signal sampling freq < Telescope sampling freq")
             
-            # circumvent this issue for subintegrated data for now...
-            if signal.subint:
-                out = np.array(sig_in, dtype=float)
-            else:
-                raise ValueError("Signal sampling freq < Telescope sampling freq")
+            # We will need to fix this eventually but for now we will circumvent
+            out = np.array(sig_in, dtype=float)
+            #raise ValueError("Signal sampling freq < Telescope sampling freq")
 
         if noise:
             # The noise is getting added to the data in the radiometer noise function; this function as no output

--- a/psrsigsim/utils/constants.py
+++ b/psrsigsim/utils/constants.py
@@ -11,3 +11,6 @@ from .utils import make_quant
 
 #constant used to be more consistent with PSRCHIVE
 DM_K =  1.0/2.41e-4 * u.MHz**2 / u.pc * u.cm**3 * u.s
+
+# Define the Kologorov Beta value for ISM scaling laws
+KOLMOGOROV_BETA = 11.0/3

--- a/tests/test_ism.py
+++ b/tests/test_ism.py
@@ -49,6 +49,23 @@ def test_FDshift(signal,pulsar,ism):
     pulsar.make_pulses(signal,tobs)
     ism.FD_shift(signal,[2e-4, -3e-4,7e-5])
 
+def test_scalinglaws(ism):
+    """"""
+    nu_i = make_quant(1400.0, 'MHz')
+    nu_f = make_quant(1200.0, 'MHz')
+    # scale scintillation bandwidth
+    dnu_d = make_quant(20.0, 'MHz')
+    ism.scale_dnu_d(dnu_d,nu_i,nu_f,beta=5)
+    ism.scale_dnu_d(dnu_d,nu_i,nu_f,beta=3)
+    # scale scintillation timescale
+    dt_d = make_quant(3600.0, 's')
+    ism.scale_dt_d(dt_d,nu_i,nu_f,beta=5)
+    ism.scale_dt_d(dt_d,nu_i,nu_f,beta=3)
+    # scale scattering timescale
+    tau_d = make_quant(5e-6, 's')
+    ism.scale_tau_d(tau_d,nu_i,nu_f,beta=5)
+    ism.scale_tau_d(tau_d,nu_i,nu_f,beta=3)
+
 def test_scattershift(signal, pulsar, ism):
     """"""
     tobs = make_quant(5,'s')

--- a/tests/test_ism.py
+++ b/tests/test_ism.py
@@ -48,3 +48,9 @@ def test_FDshift(signal,pulsar,ism):
     tobs = make_quant(5,'s')
     pulsar.make_pulses(signal,tobs)
     ism.FD_shift(signal,[2e-4, -3e-4,7e-5])
+
+def test_scattershift(signal, pulsar, ism):
+    """"""
+    tobs = make_quant(5,'s')
+    pulsar.make_pulses(signal,tobs)
+    ism.scatter_broaden(signal, 5e-6, 1400.0)

--- a/tests/test_telescope.py
+++ b/tests/test_telescope.py
@@ -21,7 +21,7 @@ def signal():
     """
     Fixture signal class
     """
-    fbsig = FilterBankSignal(1400,400)
+    fbsig = FilterBankSignal(1400,400, fold=False)
     return fbsig
 
 @pytest.fixture
@@ -30,7 +30,7 @@ def subint_signal():
     Fixture for signal class
     - Makes a subintegrated signal
     """
-    fbsubsig = FilterBankSignal(1400,400,subint=True)
+    fbsubsig = FilterBankSignal(1400,400,fold=True)
     return fbsubsig
 
 @pytest.fixture


### PR DESCRIPTION
Changed the `subint` flag in the `filterbank_signal` class to `fold` (which is either `True` or `False`). If `True,` defaults to the subintegrated filterbank style signal that we had before. If `False`, the subintegration length is assumed to be the pulse period which will effectively make single-pulse filterbank data (or search mode style filterbank data). This addresses some issue from #80 , but does not include a method to create or save a simulated signal to a PSRFITS file yet. 