### PR TITLE
Added phase connection for multiple simulated data sets

### DIFF
--- a/data/test_parfile.par
+++ b/data/test_parfile.par
@@ -1,0 +1,29 @@
+PSR              B1855+09
+LAMBDA   286.8634882751815  0     0.0000000143589
+BETA      32.3214862222730  0     0.0000000232279
+PMLAMBDA            0.0000  0              0.0000
+PMBETA              0.0000  0              0.0000
+PX                  0.0000  0              0.0000
+POSEPOCH	56000.0000
+F0    186.4940812499314404  0  0.0000000000028812
+PEPOCH        56000.000000
+START            53358.726
+FINISH           57375.734
+DM               13.299393
+SOLARN0               0.00
+EPHEM               DE436
+ECL                 IERS2010
+CLK                 TT(BIPM2015)                    
+UNITS               TDB
+TIMEEPH             FB90
+T2CMETHOD           TEMPO
+CORRECT_TROPOSPHERE N
+PLANET_SHAPIRO      N
+DILATEFREQ          N      
+TZRMJD  56000.000030664357477
+TZRFRQ  	  1379.218
+TZRSITE                  @
+JUMP -fe L-wide      0.0000000000  0
+# Converted by make_release.py on Mon Aug 14 15:30:43 2017 by pdemores
+# Original filename: 'B1855+09/B1855+09.x2e.par'
+# Ran additional tempo iteration

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy>=1.16.4
 scipy>=1.0.0
 matplotlib>=2.1.1
 h5py>=2.7.0
-astropy>=2.0
+astropy>=2.0, <4.0
 pdat>=0.2
 fitsio==0.9.12
 packaging>=19.1

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -46,5 +46,33 @@ def test_savesig(PSRfits, pulsar):
     S = PSRfits.make_signal_from_psrfits()
     obslen = PSRfits.tsubint.value*PSRfits.nsubint
     pulsar.make_pulses(S, tobs = obslen)
-    PSRfits.save(S)
+    PSRfits.save(S, pulsar)
+    os.remove("data/test.fits")
+    
+def test_savephaseconnect(PSRfits, pulsar):
+    """
+    Test getting a signal from a fits file, making pulses with it, and save it,
+    with all the phase connection functions.
+    """
+    S = PSRfits.make_signal_from_psrfits()
+    obslen = PSRfits.tsubint.value*PSRfits.nsubint
+    pulsar.make_pulses(S, tobs = obslen)
+    parfile = "data/test_parfile.par"
+    PSRfits.save(S, pulsar, phaseconnect = True, parfile = parfile, \
+                 MJD_start = 55999.9861, inc_len = 0.0, ref_MJD = 56000.0, \
+                 usePint = True)
+    os.remove("data/test.fits")
+    
+def test_savephaseconnect_inc(PSRfits, pulsar):
+    """
+    Test getting a signal from a fits file, making pulses with it, and save it,
+    with all the phase connection functions with an non-zerio increment length.
+    """
+    S = PSRfits.make_signal_from_psrfits()
+    obslen = PSRfits.tsubint.value*PSRfits.nsubint
+    pulsar.make_pulses(S, tobs = obslen)
+    parfile = "data/test_parfile.par"
+    PSRfits.save(S, pulsar, phaseconnect = True, parfile = parfile, \
+                 MJD_start = 55999.9861+30.0, inc_len = 30.0, ref_MJD = 56000.0, \
+                 usePint = True)
     os.remove("data/test.fits")


### PR DESCRIPTION
I've added phase connection functions to replace the polycos and other appropriate PSRFITS header values so that multiple simulated PSRFITS files will be phase connected for timing tests as discussed in #74. 