### PR TITLE
Added Pulse Nulling

### DIFF
--- a/psrsigsim/__init__.py
+++ b/psrsigsim/__init__.py
@@ -12,10 +12,12 @@ from . import pulsar
 from . import telescope
 from . import ism
 from . import io
+from . import utils
 
 __all__ = ["signal",
            "pulsar",
            "telescope",
            "ism",
            "io",
+           "utils",
            ]

--- a/psrsigsim/io/__init__.py
+++ b/psrsigsim/io/__init__.py
@@ -2,8 +2,10 @@
 
 from .file import BaseFile
 from .psrfits import PSRFITS
+from .txtfile import TxtFile
 
 __all__ = [
         "BaseFile",
         "PSRFITS",
+        "TxtFile",
  ]

--- a/psrsigsim/io/txtfile.py
+++ b/psrsigsim/io/txtfile.py
@@ -1,0 +1,176 @@
+# -*- coding: utf-8 -*-
+# encoding=utf8
+
+from __future__ import (absolute_import, division,
+                        print_function, unicode_literals)
+import numpy as np
+from ..utils import make_quant
+from .file import BaseFile
+
+class TxtFile(BaseFile):
+    """A class for saving PsrSigSim signals as text files.
+    Multiple different text file data types may be supported, but currently
+    only the PSRCHIVE pdv function output is supported.
+    path: name and path of new text file that will be saved
+    """
+    _path = None
+    _signal = None
+    _file = None
+
+    def __init__(self, path=None):
+        """
+        """
+        self._path = path
+        self._tbin = None
+        self._nbin = None
+        self._nchan = None
+        self._npol = None
+        self._nrows = None
+        self._tsubint = None
+        self._chan_bw = None
+        self._obsbw = None
+        self._obsfreq = None
+
+    def save_psrchive_pdv(self, signal, pulsar):
+        """
+        Function to save simulated data in the same format as the PSRCHIVE pdf function.
+        To avoid large file sizes, every hundred pulses the data will be saved as a text file.
+        Currently one a single polarization (total intensity) is supported. Inputs are:
+        
+        signal [class] : signal class object, currently only filterbank is supported
+        pulsar [class] : pulsar class object
+        filename [string] : desired name of source/output file. Output files will be saved as
+                            `filename`_#.txt, where # is the chronological number of the 
+                            files being saved.
+        """
+        # Get the signal parameters
+        self._get_signal_params(signal, pulsar)
+        # Check if there's a save path
+        if self.path == None:
+            self._path = "PsrSigSim_Simulated_Pulsar.ar"
+        # We first need to make the header
+        rms = np.sqrt((1.0/len(signal.data))*np.sum((signal.data)**2))
+        header = "# File: %s Src: %s Nsub: %s Nch: %s Npol: %s Nbin: %s RMS: %s \n" % \
+                        (self.path, pulsar.name, str(self.nrows), str(self.nchan), \
+                         str(self.npol), str(self.nbin), str(rms))
+        # Now we make a list of the lines to save
+        lines = [header]
+        if self.npol != 1:
+            print("Only saving total intensity, multiple polarizations not yet implemented")
+        # We need to dump the data every so often to avoid files that are too big
+        dump_val = 0
+        # Now we need to loop through each subint, frequency channel, and polarization
+        for ii in range(self.nrows):
+            mjd_mid = 56000.0+(ii+1)*(self.tsubint.to('day').value)/2.0
+            for ff in range(self.nchan):
+                freq = signal.dat_freq[ff].value
+                pulse_header = "# MJD(mid): %s Tsub: %s Freq: %s BW: %s \n" \
+                            % (mjd_mid, self.tsubint.value, freq, self.obsbw.value/self.nchan)
+                lines.append(pulse_header)
+                for bb in range(self.nbin):
+                    lines.append("%s %s %s %s \n" % (ii, ff, bb, signal.data[ff,bb]))
+                dump_val += 1
+            # Now save the lines in a text file
+            if dump_val >= 100:
+                file_num = str(int(np.floor(dump_val/100)))
+                with open(self.path+"_%s.txt" % (file_num), 'w') as pdv_file:
+                    pdv_file.writelines(lines)
+                    pdv_file.close()
+                lines = [header]
+        # and then we want to dump the last few lines
+        file_num = str(int(np.floor(dump_val/100)))
+        with open(self.path+"_%s.txt" % (file_num), 'w') as pdv_file:
+            pdv_file.writelines(lines)
+            pdv_file.close()
+        
+    def _get_signal_params(self, signal, pulsar):
+        """
+        Retrieve the various parameters needed to save the file from
+        a PSS signal class.
+        """
+        # get parameters from signal class
+        self.nchan = signal.Nchan
+        self.tbin = 1.0/signal.samprate
+        self.nbin = int((signal.samprate * pulsar.period).decompose())
+        self.npol = signal.Npols
+        self.nrows = signal.nsub
+        self.obsfreq = signal.fcent
+        self.obsbw = signal.bw
+        self.chan_bw = signal.bw / signal.Nchan
+        self.tsubint = signal.sublen # length of subint in seconds
+        self.nsubint = self.nrows
+            
+      #### Define various PSRFITS parameters
+    @property
+    def tbin(self):
+        return self._tbin
+
+    @tbin.setter
+    def tbin(self, value):
+        self._tbin = make_quant(value,'s')
+
+    @property
+    def npol(self):
+        return self._npol
+
+    @npol.setter
+    def npol(self, value):
+        self._npol = value
+
+    @property
+    def nchan(self):
+        return self._nchan
+
+    @nchan.setter
+    def nchan(self, value):
+        self._nchan = value
+
+    @property
+    def nbin(self):
+        return self._nbin
+
+    @nbin.setter
+    def nbin(self, value):
+        self._nbin = value
+
+    @property
+    def nrows(self):
+        return self._nrows
+
+    @nrows.setter
+    def nrows(self, value):
+        self._nrows = value
+
+    @property
+    def obsfreq(self):
+        return self._obsfreq
+
+    @obsfreq.setter
+    def obsfreq(self, value):
+        self._obsfreq = make_quant(value,'MHz')
+
+    @property
+    def obsbw(self):
+        return self._obsbw
+
+    @obsbw.setter
+    def obsbw(self, value):
+        self._obsbw = make_quant(value,'MHz')
+
+    @property
+    def chan_bw(self):
+        return self._chan_bw
+
+    @chan_bw.setter
+    def chan_bw(self, value):
+        self._chan_bw = make_quant(value,'MHz')
+        
+    @property
+    def tsubint(self):
+        return self._tsubint
+    
+    @tsubint.setter
+    def tsubint(self, value):
+        self._tsubint = make_quant(value, 'second')     
+            
+            

--- a/psrsigsim/ism/ism.py
+++ b/psrsigsim/ism/ism.py
@@ -38,15 +38,24 @@ class ISM(object):
         #freq in MHz, delays in milliseconds
         freq_array = signal._dat_freq
         time_delays = (DM_K * dm * np.power(freq_array,-2)).to('ms')
+        if signal.delay==None:
+            signal._delay=time_delays
+        else:
+            signal._delay += time_delays
         #Dispersion as compared to infinite frequency
         shift_dt = (1/signal._samprate).to('ms')
         shift_start = time.time()
+        # check if there are less than 20 frequency channels
+        if signal.Nchan <= 20:
+            div_fac = 1
+        else:
+            div_fac = 20
 
         for ii, freq in enumerate(freq_array):
             signal._data[ii,:] = shift_t(signal._data[ii,:],
                                          time_delays[ii].value,
                                          dt=shift_dt.value)
-            if (ii+1) % int(signal.Nchan//20) ==0:
+            if (ii+1) % int(signal.Nchan//div_fac) ==0:
                 shift_check = time.time()
                 percent = round((ii + 1)*100/signal.Nchan)
                 elapsed = shift_check-shift_start
@@ -109,15 +118,24 @@ class ISM(object):
             time_delays += np.double(make_quant(FD_params[ii], 's').to('ms') * \
                     np.power(np.log(freq_array/ref_freq),ii+1)) # will be in seconds
         
+        if signal.delay==None:
+            signal._delay=time_delays
+        else:
+            signal._delay += time_delays
         # get time shift based on the sample rate
         shift_dt = (1/signal._samprate).to('ms')
         shift_start = time.time()
+        # check if there are less than 20 frequency channels
+        if signal.Nchan <= 20:
+            div_fac = 1
+        else:
+            div_fac = 20
 
         for ii, freq in enumerate(freq_array):
             signal._data[ii,:] = shift_t(signal._data[ii,:],
                                          time_delays[ii].value,
                                          dt=shift_dt.value)
-            if (ii+1) % int(signal.Nchan//20) ==0:
+            if (ii+1) % int(signal.Nchan//div_fac) ==0:
                 shift_check = time.time()
                 percent = round((ii + 1)*100/signal.Nchan)
                 elapsed = shift_check-shift_start
@@ -164,15 +182,24 @@ class ISM(object):
         tau_d_scaled = self.scale_tau_d(tau_d, ref_freq , freq_array, beta=beta)
         # First shift signal if convolve = False
         if not convolve:
+            if signal.delay==None:
+                signal._delay=tau_d_scaled
+            else:
+                signal._delay += tau_d_scaled
             # define bin size to shift by
             shift_dt = (1/signal._samprate).to('ms')
             shift_start = time.time()
+            # check if there are less than 20 frequency channels
+            if signal.Nchan <= 20:
+                div_fac = 1
+            else:
+                div_fac = 20
             # now loop through and scale things appropriately
             for ii, freq in enumerate(freq_array):
                 signal._data[ii,:] = shift_t(signal._data[ii,:],
                                              tau_d_scaled[ii].value,
                                              dt=shift_dt.value)
-                if (ii+1) % int(signal.Nchan//20) ==0:
+                if (ii+1) % int(signal.Nchan//div_fac) ==0:
                     shift_check = time.time()
                     percent = round((ii + 1)*100/signal.Nchan)
                     elapsed = shift_check-shift_start

--- a/psrsigsim/pulsar/portraits.py
+++ b/psrsigsim/pulsar/portraits.py
@@ -56,6 +56,28 @@ class PulsePortrait(object):
         This is implemented by the subclasses!
         """
         raise NotImplementedError()
+        
+    def _calcOffpulseWindow(self, Nphase = None):
+        """
+        Function adapted from Pypulse (https://github.com/mtlam/PyPulse)
+        to determine the offpulse window of the input profile
+        """
+        # Find minimum in the area
+        if Nphase == None:
+            windowsize = 2048/8
+        else:
+            windowsize = Nphase/8
+        
+        bins = np.arange(0, Nphase)
+
+        integral = np.zeros_like(self._max_profile)
+        for i in bins:
+            win = np.arange(i-windowsize//2, i+windowsize//2) % Nphase
+            integral[i] = np.trapz(self._max_profile[win.astype(int)])
+        minind = np.argmin(integral)
+        opw = np.arange(minind-windowsize//2, minind+windowsize//2+1)
+        opw = opw % Nphase
+        return opw
 
     @property
     def profiles(self):

--- a/psrsigsim/pulsar/pulsar.py
+++ b/psrsigsim/pulsar/pulsar.py
@@ -6,7 +6,7 @@ from scipy import stats
 from .profiles import GaussProfile
 from .profiles import UserProfile
 from .profiles import DataProfile
-from ..utils.utils import make_quant
+from ..utils.utils import make_quant, shift_t
 
 class Pulsar(object):
     """class for pulsars
@@ -194,6 +194,10 @@ class Pulsar(object):
         """
         Function to simulate pulsar pulse nulling. Given some nulling fraction,
         will replace simulated pulses with noise until nulling fraction is met.
+        This function should only be run after running any ism or other delays
+        have been added, e.g. disperison, FD, profile evolution, etc., but 
+        should be run before adding the radiometer noise ('telescope.observe()`),
+        if nulling is desired.
         
         signal [class] : signal class containing the simulated pulses
         null_frac [float] : desired pulsar nulling fraction, given as a 
@@ -206,8 +210,65 @@ class Pulsar(object):
                             of time. If not given, will randomly null pulses.
                             Default is None.
         """
+        # Determine how many pulses need to be nulled out
+        null_pulses = int(np.round(signal.nsub * null_frac)) # needs to be int, may not be exact
+        # Get the number of bins per pulse
+        Nph = int((signal.samprate * self.period).decompose())
+        # determine the off pulse window
+        opw = self.Profiles._calcOffpulseWindow(Nphase = Nph)
+        # define the random noise distribution
+        if signal.fold:
+            distr = stats.chi2(df=signal.Nfold)
+        else:
+            distr = stats.chi2(df=1)
+        # Figure out how off-center the pulses are
+        shift_val = Nph//2 - np.where(signal.data[0,:Nph]==np.max(signal.data[0,:Nph]))[0]
+        # Now null randomly if no length or frequency is given
+        if length==None and frequency==None:
+            # randomly draw pulse numbers to null
+            rand_pulses = np.random.choice(signal.nsub, null_pulses, replace=False)
+            # replace each pulse number with random noise
+            if signal.delay == None:
+                for p in rand_pulses:
+                    # convert to bins
+                    null_bins = np.arange(Nph*p, Nph*(p+1)) + shift_val
+                    # make sure we don't go beyond the data array length
+                    null_bins = null_bins[null_bins<np.shape(signal.data)[1]]
+                    # replace pulses with noise
+                    if len(null_bins) != Nph:
+                        noise = (distr.rvs(size=len(null_bins)) * signal._draw_norm)
+                    else:
+                        noise = (distr.rvs(size=Nph) * signal._draw_norm)
+                    # if no extra delays have been added to the signal
+                    signal._data[:,null_bins] = noise * np.mean(self.Profiles._max_profile[opw.astype(int)])
+            # if if signal has been delayed (e.g dispersed, etc.)
+            else:
+                # First initialize new array
+                null_array = np.zeros(np.shape(signal.data))
+                for p in rand_pulses:
+                    #null_bins = np.arange(Nph*p, Nph*(p+1))
+                    null_bins = np.arange(Nph*p, Nph*(p+1)) + shift_val
+                    # make sure we don't go beyond the data array length
+                    null_bins = null_bins[null_bins<np.shape(signal.data)[1]]
+                    # replace the appropriate arrays
+                    if len(null_bins) != Nph:
+                        null_array[:,null_bins] = (distr.rvs(size=len(null_bins)) * signal._draw_norm)
+                    else:
+                        null_array[:,null_bins] = (distr.rvs(size=Nph) * signal._draw_norm)
+                # now shift the data
+                freq_array = signal._dat_freq
+                shift_dt = (1/signal._samprate).to('ms')
+                for ii, freq in enumerate(freq_array):
+                    null_array[ii,:] = shift_t(null_array[ii,:],
+                                                 signal.delay[ii].value,
+                                                 dt=shift_dt.value)
+                # Now replace pulses with noise
+                noise_shape = np.shape(np.where(null_array>1))[1]
+                noise = (distr.rvs(size=noise_shape) * signal._draw_norm)
+                signal._data[np.where(null_array>1)] = noise*np.mean(self.Profiles._max_profile[opw.astype(int)])
         
-        raise NotImplementedError("Null function has not been implimented yet")
+        else:
+            raise NotImplementedError("Length and Frequency not been implimented yet")
         
         
         

--- a/psrsigsim/pulsar/pulsar.py
+++ b/psrsigsim/pulsar/pulsar.py
@@ -189,3 +189,25 @@ class Pulsar(object):
 
             signal._data = (full_prof * distr.rvs(size=signal.data.shape)
                             * signal._draw_norm)
+
+    def null(self, signal, null_frac, length=None, frequency=None):
+        """
+        Function to simulate pulsar pulse nulling. Given some nulling fraction,
+        will replace simulated pulses with noise until nulling fraction is met.
+        
+        signal [class] : signal class containing the simulated pulses
+        null_frac [float] : desired pulsar nulling fraction, given as a 
+                            decimal; range of 0.0 to 1.0.
+        length [float] : desired length of each null in seconds. If not given,
+                         will randomly null pulses. Default is None.
+        frequency [float] : frequency of pulse nulling, e.g. how often the pulsar
+                            nulls per hour. E.g. if frequency is 2, then the 
+                            pulsar will null twice per hour for some length
+                            of time. If not given, will randomly null pulses.
+                            Default is None.
+        """
+        
+        raise NotImplementedError("Null function has not been implimented yet")
+        
+        
+        

--- a/psrsigsim/signal/fb_signal.py
+++ b/psrsigsim/signal/fb_signal.py
@@ -107,6 +107,9 @@ class FilterBankSignal(BaseSignal):
 
         self._dtype = dtype
         self._set_draw_norm()
+        
+        # set total delay added to signal to be None
+        self._delay = None
 
     def _set_draw_norm(self, df=1):
         if self.dtype is np.float32:

--- a/psrsigsim/signal/signal.py
+++ b/psrsigsim/signal/signal.py
@@ -62,6 +62,9 @@ class BaseSignal(object):
         else:
             msg = "Only total intensity polarization is currently supported"
             raise ValueError(msg)
+        
+        # set total delay added to signal to be None
+        self._delay = None
 
     def __repr__(self):
         return self.sigtype+"({0}, bw={1})".format(self.fcent, self.bw)
@@ -140,6 +143,10 @@ class BaseSignal(object):
     @property
     def dat_freq(self):
         return self._dat_freq
+    
+    @property
+    def delay(self):
+        return self._delay
 
 
 def Signal():

--- a/psrsigsim/utils/__init__.py
+++ b/psrsigsim/utils/__init__.py
@@ -1,6 +1,6 @@
 
 from .plot import profile_plot
-from .utils import make_quant
+from .utils import make_quant, shift_t
 
 
 __all__ = []

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -13,6 +13,17 @@ from psrsigsim.signal.fb_signal import FilterBankSignal
 from psrsigsim.pulsar.pulsar import Pulsar
 from psrsigsim.io.psrfits import PSRFITS
 from psrsigsim.utils.utils import make_quant
+from psrsigsim.io.txtfile import TxtFile
+
+@pytest.fixture
+def signal():
+    """
+    Fixture signal class
+    """
+    fbsig = FilterBankSignal(1400,400,Nsubband=2,\
+                             sample_rate=186.49408124993144*2048*10**-6,\
+                             sublen=0.5)
+    return fbsig
 
 @pytest.fixture
 def pulsar():
@@ -31,6 +42,14 @@ def PSRfits():
     fitspath = "data/test.fits"
     tempfits = "data/B1855+09.L-wide.PUPPI.11y.x.sum.sm"
     return PSRFITS(path=fitspath, template=tempfits, fits_mode='copy')
+
+@pytest.fixture
+def TXTfile():
+    """
+    Fixture txtfile class
+    """
+    pdvpath = "data/test_pdv"
+    return TxtFile(path=pdvpath)
 
 def test_fitssig(PSRfits):
     """
@@ -76,3 +95,10 @@ def test_savephaseconnect_inc(PSRfits, pulsar):
                  MJD_start = 55999.9861+30.0, inc_len = 30.0, ref_MJD = 56000.0, \
                  usePint = True)
     os.remove("data/test.fits")
+    
+def test_savepdv(TXTfile, signal, pulsar):
+    tobs = make_quant(1,'s')
+    pulsar.make_pulses(signal,tobs)
+    TXTfile.save_psrchive_pdv(signal, pulsar)
+    os.remove("data/test_pdv_0.txt")
+


### PR DESCRIPTION
Added function to null some percentage of simulated pulses (pulse nulling) to the `pulsar` class. To do this, minor changes were added to the `signal` and `filterbank signal` classes as well as some `init` scripts. Additionally added a class `txtfile` to the `io` class to take simulated signals and save them as various different text files. Currently only an output similar to the `PSRCHIVE pdv` function is available. Added tests for `txtfile` class in `test_io`. Finally, fixed a bug in `ism disperse` function that would cause it to crash if fewer than 20 frequency channels were simulated. This all builds upon issue #96 .