### PR TITLE
Added G/ASP to default telescopes, added saving option

### DIFF
--- a/psrsigsim/io/psrfits.py
+++ b/psrsigsim/io/psrfits.py
@@ -250,7 +250,7 @@ class PSRFITS(BaseFile):
     # Save the signal
     def save(self, signal, pulsar, phaseconnect=False, parfile = None, \
              MJD_start = 56000.0, segLength = 60.0, inc_len = 0.0, \
-             ref_MJD = 56000.0, usePint = True, eq_wts = True):
+             ref_MJD = 56000.0, usePint = True, eq_wts = True, copymetadata = True):
         """Save PSS signal file to disk. Currently only one mode of doing this
         is supported. Saved data can be phase connected but PSRFITS file metadata must
         be edited appropriately as well and requires the following input:
@@ -274,6 +274,8 @@ class PSRFITS(BaseFile):
         eq_wts [bool] : If `True` (default), replaces the data weights so that each subintegration and 
                         frequency channel have an equal weight in the file. If `False`, just copies the
                         weights from the template file.
+        copymetadata [bool] : If `True` (default), will copy the file metadata into the 
+                            simulated fitsfile. 
         """
         
         """
@@ -297,7 +299,7 @@ class PSRFITS(BaseFile):
             idxF = idx0 + 2048
             Out[ii,0,:,:] = sim_sig[:,idx0:idxF]
         
-        self.copy_psrfit_BinTables()
+        self.copy_psrfit_BinTables(copy_SUBINT_nonDATA=copymetadata)
         # We can currently only make total intensity data
         self.file.set_draft_header('SUBINT',{'POL_TYPE':'AA+BB'})
         for ii in range(self.nsubint):

--- a/psrsigsim/telescope/telescope.py
+++ b/psrsigsim/telescope/telescope.py
@@ -180,6 +180,13 @@ def GBT():
     g.add_system(name="Lband_GUPPI",
                  receiver=Receiver(fcent=1400, bandwidth=800, name="Lband"),  # check me
                  backend=Backend(samprate=12.5, name="GUPPI"))
+    # Parameters from NANOGrav 9 year paper
+    g.add_system(name="800_GASP",
+                 receiver=Receiver(fcent=844, bandwidth=64, name="800"),  # check me
+                 backend=Backend(samprate=0.25, name="GASP"))
+    g.add_system(name="Lband_GASP",
+                 receiver=Receiver(fcent=1410, bandwidth=64, name="Lband"),  # check me
+                 backend=Backend(samprate=0.25, name="GASP"))
     return g
 
 
@@ -199,4 +206,18 @@ def Arecibo():
     a.add_system(name="Sband_PUPPI",
                  receiver=Receiver(fcent=2030, bandwidth=400, name="Sband"),  # check me
                  backend=Backend(samprate=12.5, name="PUPPI"))
+    # Parameters from NANOGrav 9 year paper
+    a.add_system(name="327_ASP",
+                 receiver=Receiver(fcent=327, bandwidth=64, name="327"),  # check me
+                 backend=Backend(samprate=0.25, name="ASP"))
+    a.add_system(name="430_ASP",
+                 receiver=Receiver(fcent=432, bandwidth=64, name="430"),  # check me
+                 backend=Backend(samprate=0.25, name="ASP"))
+    a.add_system(name="Lband_ASP",
+                 receiver=Receiver(fcent=1412, bandwidth=64, name="Lband"),  # check me
+                 backend=Backend(samprate=0.25, name="ASP"))
+    a.add_system(name="Sband_ASP",
+                 receiver=Receiver(fcent=2348, bandwidth=64, name="Sband"),  # check me
+                 backend=Backend(samprate=0.25, name="ASP"))
+
     return a


### PR DESCRIPTION
Added G/ASP backend-receiver combos as part of the default setup for the GBT and Arecibo telescopes in the telescope class. Added option to not overwrite template fitsfile metadata when saving a new fits file with simulated data.