### PR TITLE
Adding DM property 

### DIFF
--- a/psrsigsim/signal/signal.py
+++ b/psrsigsim/signal/signal.py
@@ -62,9 +62,11 @@ class BaseSignal(object):
         else:
             msg = "Only total intensity polarization is currently supported"
             raise ValueError(msg)
-        
+
         # set total delay added to signal to be None
         self._delay = None
+
+        self._dm = None
 
     def __repr__(self):
         return self.sigtype+"({0}, bw={1})".format(self.fcent, self.bw)
@@ -143,10 +145,18 @@ class BaseSignal(object):
     @property
     def dat_freq(self):
         return self._dat_freq
-    
+
     @property
     def delay(self):
         return self._delay
+
+    @property
+    def dm(self):
+        return self._dm
+
+    @property
+    def DM(self):
+        return self._dm
 
 
 def Signal():

--- a/tests/test_ism.py
+++ b/tests/test_ism.py
@@ -42,6 +42,7 @@ def test_disperse(signal,pulsar,ism):
     tobs = make_quant(5,'s')
     pulsar.make_pulses(signal,tobs)
     ism.disperse(signal,10)
+    assert signal.dm.value==10
 
 def test_FDshift(signal,pulsar,ism):
     """"""
@@ -77,4 +78,3 @@ def test_scatterbroaden(signal, pulsar, ism):
     tobs = make_quant(5,'s')
     ism.scatter_broaden(signal, 5e-6, 1400.0, convolve=True,pulsar=pulsar)
     pulsar.make_pulses(signal,tobs)
-    


### PR DESCRIPTION
This PR is response to Issue #115. The DM was available as `signal._dm`, but was not available as a proper property. It has now been added into the base signal class. It was not added to the `ism` class, as the DM can be changed to disperse other signals. 