### PR TITLE
Add signal tests

### DIFF
--- a/psrsigsim/signal/bb_signal.py
+++ b/psrsigsim/signal/bb_signal.py
@@ -27,18 +27,21 @@ class BasebandSignal(BaseSignal):
 
         dtype [type]: data type of array, default: ``np.float32``
             any numpy compatible floating point type will work
+            
+        Nchan [int]: number of frequency channels to simulate, default is 2.
     """
 
     _sigtype = "BasebandSignal"
-    _Nchan = 2
 
     def __init__(self,
                  fcent, bandwidth,
                  sample_rate=None,
-                 dtype=np.float32):
+                 dtype=np.float32,
+                 Nchan = 2):
 
         self._fcent = make_quant(fcent, 'MHz')
         self._bw = make_quant(bandwidth, 'MHz')
+        self._Nchan = Nchan
 
         f_Nyquist = 2 * self._bw
         if sample_rate is None:

--- a/psrsigsim/signal/signal.py
+++ b/psrsigsim/signal/signal.py
@@ -162,4 +162,4 @@ class BaseSignal(object):
 def Signal():
     """helper function to instantiate signals
     """
-    pass
+    raise NotImplementedError()

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -129,3 +129,4 @@ def test_notimplementedfuncs(PSRfits, signal):
         PSRfits.to_psrfits()
         PSRfits.set_sky_info()
         PSRfits._calc_psrfits_dims(signal)
+    os.remove("data/test.fits")

--- a/tests/test_ism.py
+++ b/tests/test_ism.py
@@ -4,15 +4,13 @@
 """Tests for `psrsigsim.ism` module."""
 
 import pytest
-import psrsigsim as pss
-import psrsigsim.signal as sig
-import psrsigsim.pulsar as psr
-import psrsigsim.ism as ism
 
 from psrsigsim.signal.fb_signal import FilterBankSignal
+from psrsigsim.signal.bb_signal import BasebandSignal
 from psrsigsim.pulsar.pulsar import Pulsar
 from psrsigsim.ism.ism import ISM
 from psrsigsim.utils.utils import make_quant
+import numpy as np
 
 @pytest.fixture
 def signal():
@@ -21,6 +19,14 @@ def signal():
     """
     fbsig = FilterBankSignal(1400,400)
     return fbsig
+
+@pytest.fixture
+def bbsignal():
+    """
+    Fixture baseband signal class
+    """
+    bbsig = BasebandSignal(1400,400)
+    return bbsig
 
 @pytest.fixture
 def pulsar():
@@ -38,20 +44,47 @@ def ism():
     return ISM()
 
 def test_disperse(signal,pulsar,ism):
-    """"""
+    """
+    Test disperse function with filterbank signal.
+    """
     tobs = make_quant(5,'s')
     pulsar.make_pulses(signal,tobs)
     ism.disperse(signal,10)
     assert signal.dm.value==10
+    with pytest.raises(ValueError):
+        ism.disperse(signal,10)
+        
+#def test_bb_disperse(bbsignal,pulsar,ism):
+#    """
+#    Test disperse function with baseband signal.
+#    """
+#    tobs = make_quant(0.05,'s')
+#    pulsar.make_pulses(bbsignal,tobs)
+#    ism.disperse(bbsignal,10)
+#    assert bbsignal.dm.value==10
+
+def test_add_delay(signal,pulsar,ism):
+    """
+    Test add delay from dispersion class.
+    """
+    tobs = make_quant(5,'s')
+    pulsar.make_pulses(signal,tobs)
+    signal._delay = np.repeat(make_quant(1.0,'ms'), len(signal._dat_freq))
+    ism.disperse(signal,10)
+    assert signal.dm.value==10
 
 def test_FDshift(signal,pulsar,ism):
-    """"""
+    """
+    Test FD shift function.
+    """
     tobs = make_quant(5,'s')
     pulsar.make_pulses(signal,tobs)
     ism.FD_shift(signal,[2e-4, -3e-4,7e-5])
 
 def test_scalinglaws(ism):
-    """"""
+    """
+    Test scaling law functions
+    """
     nu_i = make_quant(1400.0, 'MHz')
     nu_f = make_quant(1200.0, 'MHz')
     # scale scintillation bandwidth
@@ -68,13 +101,17 @@ def test_scalinglaws(ism):
     ism.scale_tau_d(tau_d,nu_i,nu_f,beta=3)
 
 def test_scattershift(signal, pulsar, ism):
-    """"""
+    """
+    Test direct scattering shift in time.
+    """
     tobs = make_quant(5,'s')
     pulsar.make_pulses(signal,tobs)
     ism.scatter_broaden(signal, 5e-6, 1400.0)
 
 def test_scatterbroaden(signal, pulsar, ism):
-    """"""
+    """
+    Test pulsar scatter broadening with convolution.
+    """
     tobs = make_quant(5,'s')
     ism.scatter_broaden(signal, 5e-6, 1400.0, convolve=True,pulsar=pulsar)
     pulsar.make_pulses(signal,tobs)

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tests for `psrsigsim.signal` module."""
+
+import pytest
+
+import numpy as np
+
+from psrsigsim.signal.fb_signal import FilterBankSignal
+from psrsigsim.signal.bb_signal import BasebandSignal
+from psrsigsim.signal.rf_signal import RFSignal
+from psrsigsim.signal.signal import BaseSignal, Signal
+from psrsigsim.utils.utils import make_quant
+
+def test_basesignal():
+    """
+    Test BaseSignal class.
+    """
+    bs1 = BaseSignal(1400, 400, sample_rate=None, dtype=np.float32, Npols=1)
+    # Test some functions
+    sig_names = bs1.__repr__()
+    bs1._Nchan = 2
+    bs1.init_data(5)
+    # Check some properties
+    assert(bs1.Nchan == 2)
+    assert(isinstance(bs1.data, np.ndarray))
+    assert(bs1.sigtype == 'Signal')
+    assert(bs1.fcent == 1400)
+    assert(bs1.bw == 400)
+    assert(bs1.samprate == None)
+    assert(bs1.dtype == np.float32)
+    assert(bs1.Npols == 1)
+    assert(bs1.delay == None)
+    assert(bs1.dm == None)
+    assert(bs1.DM == None)
+
+def test_basesignal_errors():
+    """
+    Test BaseSignal class errors.
+    """
+    with pytest.raises(ValueError):
+        # Test invalid data type
+        bs2 = BaseSignal(1400, -400, sample_rate=None, dtype=np.float64, Npols=1)
+        # Test invalid polarizations
+        bs3 = BaseSignal(1400, -400, sample_rate=None, dtype=np.float64, Npols=4)
+    # Good signal
+    bs1 = BaseSignal(1400, 400, sample_rate=None, dtype=np.float32, Npols=1)
+    with pytest.raises(NotImplementedError):
+        bs1.__add__(bs1)
+        bs1._set_draw_norm()
+        bs1.to_RF()
+        bs1.to_Baseband()
+        bs1.to_FilterBank()
+        Signal()
+        
+def test_fbsignal():
+    """
+    Test Filterbank Signal class.
+    """
+    # standard instantiation
+    fbsig1 = FilterBankSignal(1400,400,Nsubband=2,\
+                             sample_rate=186.49408124993144*2048*10**-6,\
+                             sublen=0.5)
+    # minimal instantiation
+    fbsig2 = FilterBankSignal(1400,-400,Nsubband=2,\
+                             sample_rate=None,\
+                             sublen=None, fold=False)
+    # Check return of self
+    fbsig_test = fbsig1.to_FilterBank()
+    assert(fbsig_test == fbsig1)
+    
+    # Check _set_draw_norm function
+    fbsig3 = FilterBankSignal(1400,-400,Nsubband=2,\
+                             sample_rate=None,\
+                             sublen=None, dtype=np.int8, fold=False)
+
+def test_fbsignal_errs():
+    """
+    Test Filterbank Signal class errors.
+    """
+    # Test errors
+    fbsig1 = FilterBankSignal(1400,400,Nsubband=2,\
+                             sample_rate=186.49408124993144*2048*10**-6,\
+                             sublen=0.5)
+    with pytest.raises(NotImplementedError):
+        fbsig1.to_RF()
+        fbsig1.to_Baseband()
+
+def test_bbsignal():
+    """
+    Test Baseband Signal class.
+    """
+    # standard instantiation
+    bbsig1 = BasebandSignal(1400, 400,
+                 sample_rate=186.49408124993144*2048*10**-6,
+                 dtype=np.float32,
+                 Nchan = 2)
+    # minmal instantiation
+    bbsig2 = BasebandSignal(1400, 400,
+                 sample_rate=None,
+                 dtype=np.float32,
+                 Nchan = 2)
+    # Check return of self
+    bbsig_test = bbsig1.to_Baseband()
+    assert(bbsig_test == bbsig1)
+
+def test_bbsigna_errorsl():
+    """
+    Test Baseband Signal class errors.
+    """
+    # Test errors
+    bbsig1 = BasebandSignal(1400, 400,
+                 sample_rate=186.49408124993144*2048*10**-6,
+                 dtype=np.float32,
+                 Nchan = 2)
+    with pytest.raises(NotImplementedError):
+        bbsig1.to_RF()
+        bbsig1.to_FilterBank()
+    
+def test_rfsignal():
+    """
+    Test RF Signal class.
+    """
+    # Standard intialization
+    rfsig1 = RFSignal(1400, 400,
+                 sample_rate=186.49408124993144*2048*10**-6,
+                 dtype=np.float32)
+    # minimal initialization
+    rfsig2 = RFSignal(1400, 400,
+                 sample_rate=None,
+                 dtype=np.float32)
+    # Check return of self
+    rfsig_test = rfsig1.to_RF()
+    assert(rfsig1 == rfsig_test)
+    
+def test_rfsignal_errors():
+    """
+    Test RF Signal class errors.
+    """
+    # Standard intialization
+    rfsig1 = RFSignal(1400, 400,
+                 sample_rate=186.49408124993144*2048*10**-6,
+                 dtype=np.float32)
+    with pytest.raises(NotImplementedError):
+        rfsig1.to_Baseband()
+        rfsig1.to_FilterBank()
+    


### PR DESCRIPTION
Added tests for the signal class, include the base signal class, filterbank signal, baseband signal, and RF signal. Coverage is much increased. Also fixed a few very small bugs. This PR also includes a fix to the `test_io.py` script where a spurious test PSRFITS file was created and not removed in the testing. I believe this has been fixed now.