### PR TITLE
Added Py3.8 to Travis CI, and changed astropy version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@
 
 language: python
 python:
+  - 3.8
   - 3.7
   - 3.6
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy>=1.16.4
 scipy>=1.0.0
 matplotlib>=2.1.1
 h5py>=2.7.0
-astropy>=2.0, <4.0
+astropy>=3.2,!=4.0.1,!=4.0.1.post1
 pdat>=0.2
 fitsio==0.9.12
 packaging>=19.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy>=1.16.4
 scipy>=1.0.0
 matplotlib>=2.1.1
 h5py>=2.7.0
-astropy>=3.2,!=4.0.1,!=4.0.1.post1
+astropy>=2.0, <4.0
 pdat>=0.2
 fitsio==0.9.12
 packaging>=19.1

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ requirements = [
     'matplotlib>=2.0.0',
     'h5py',
     'pdat',
+    'astropy>=3.2,!=4.0.1,!=4.0.1.post1',
     'pint-pulsar',
 ]
 
@@ -58,9 +59,9 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     test_suite='tests',
     tests_require=test_requirements,

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ requirements = [
     'matplotlib>=2.0.0',
     'h5py',
     'pdat',
-    'astropy>=3.2,!=4.0.1,!=4.0.1.post1',
     'pint-pulsar',
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
-envlist = py35, py36, py37, flake8
+envlist = py36, py37, py38, flake8
 
 [travis]
 python =
-    3.5: py35
     3.6: py36
     3.7: py37
+    3.8: py38
 
 [testenv:flake8]
 basepython=python


### PR DESCRIPTION
Adding tests for `Python 3.8`. Additionally I've updated the `astropy` versions to match what is allowable by `pint-pulsar`.