### PR TITLE
use PCHIP interpolator

### DIFF
--- a/psrsigsim/pulsar/portraits.py
+++ b/psrsigsim/pulsar/portraits.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division,
                         print_function, unicode_literals)
 import numpy as np
 from astropy import log
-from scipy.interpolate import CubicSpline as _cubeSpline
+from scipy.interpolate import PchipInterpolator as _pchipInterp
 
 
 class PulsePortrait(object):
@@ -249,8 +249,7 @@ class DataPortrait(PulsePortrait):
                 # enforce periodicity!
                 profiles[:,-1] = profiles[:,0]
 
-        self._generator = _cubeSpline(phases, profiles, axis=1,
-                                      bc_type='periodic')
+        self._generator = _pchipInterp(phases, profiles, axis=1)
 
     def calc_profiles(self, phases, Nchan=None):
         """


### PR DESCRIPTION
Cubic Spline is a pretty standard interpolation method.  It has continuous first and second derivatives, and the `scipy` implementation can handle periodic boundary conditions.  The draw back is that it can "overshoot" data.  Even though the data profile is strictly non-negative, the spline can dip below zero.

[Piecewise Cubic Hermite Interpolating Polynomial (PCHIP)](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.PchipInterpolator.html) is another method.  It only has continuous first derivatives, and the `scipy` implementation doesn't allow you to specify the boundary conditions.  It is monotonic between all specified points, so it never overshoots.

The interpolated J1713 profile differs on the 0.1% level relative to the maximum:
![image](https://user-images.githubusercontent.com/7785231/98039384-9d17c480-1dec-11eb-9d15-9150523ded7f.png)

If a profile wraps around the 0/1 phase boundary, the derivative of the profile won't necessarily be continuous across the wrap.  We give up the periodic boundary condition, but I don't think it really matters.