### PR TITLE
Found and fixed profile convolution bug

### DIFF
--- a/psrsigsim/ism/ism.py
+++ b/psrsigsim/ism/ism.py
@@ -265,11 +265,15 @@ class ISM(object):
         for ii, freq in enumerate(convolve_array):
             #Normalizing the pulse profile
             pulsar_prof_sum = np.sum(profiles[ii,:])
-            pulsar_prof_norm = profiles[ii,:] / pulsar_prof_sum
+            # check divide by zero
+            if pulsar_prof_sum != 0.0:
+                pulsar_prof_norm = profiles[ii,:] / pulsar_prof_sum
 
             #Normalizing the input array
             convolve_array_sum = np.sum(convolve_array[ii,:])
-            convolve_array_norm = convolve_array[ii,:] / convolve_array_sum
+            # Check divide by zero
+            if convolve_array_sum != 0.0:
+                convolve_array_norm = convolve_array[ii,:] / convolve_array_sum
 
             #Convolving the input array with the pulse profile
             convolved_prof = spsig.convolve(pulsar_prof_norm, convolve_array_norm, \


### PR DESCRIPTION
Fixed a bug where if you have a profile full of zeros and try to convolve it with a scattering tail, it returns an array of `nans`. This causes the profile interpolation to break. Now if you start with a profile that is just zeros, it should return a profile of just zeros.